### PR TITLE
Initialize monorepo with Next.js frontend and FastAPI backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,36 +1,36 @@
-# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+# Node
+node_modules/
+.next/
+out/
+.pnp.cjs
+.pnp.loader.mjs
+yarn.lock
+package-lock.json
+pnpm-lock.yaml
 
-# dependencies
-/node_modules
-/.pnp
-.pnp.js
-
-# testing
-/coverage
-
-# next.js
-/.next/
-/out/
-
-# production
-/build
-
-# misc
-.DS_Store
-*.pem
-
-# debug
+# Logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+lerna-debug.log*
 
-# local env files
-.env*.local
+# Editor directories and files
+.vscode/
+.idea/
+.DS_Store
+*.swp
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
 .env
+.venv/
 
-# vercel
-.vercel
+# Coverage
+coverage/
+.pytest_cache/
 
-# typescript
-*.tsbuildinfo
-next-env.d.ts
+# Build artifacts
+build/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
-# gpt5-nyc-hackathon
+# GPT5 Hackathon Monorepo Starter
+
+A batteries-included monorepo that pairs a modern Next.js frontend with a FastAPI backend. The structure is optimized for teams collaborating on product features and services simultaneously.
+
+## Repository layout
+
+```
+.
+├── frontend/      # Next.js 14 + Tailwind CSS + shadcn/ui-inspired components
+├── backend/       # FastAPI service with modular routers and typed schemas
+├── .gitignore
+└── README.md
+```
+
+## Getting started
+
+### Frontend
+
+```bash
+cd frontend
+pnpm install  # or npm install / yarn install
+pnpm dev
+```
+
+Visit `http://localhost:3000` to view the application. The starter ships with Tailwind CSS, Radix Themes, and Framer Motion ready to use.
+
+### Backend
+
+```bash
+cd backend
+poetry install
+poetry run uvicorn app.main:app --reload
+```
+
+Open `http://localhost:8000/docs` for interactive OpenAPI documentation.
+
+## Development conventions
+
+- **Code quality** — ESLint, TypeScript, Prettier, Ruff, and Black keep contributions consistent.
+- **Isolation** — Frontend and backend live in separate workspaces so teams can deploy independently.
+- **Shared patterns** — Components, schemas, and services are organized to encourage reuse and clear boundaries.
+
+## Next steps
+
+- Connect the frontend to backend APIs using `@tanstack/react-query`.
+- Add CI workflows for linting, testing, and type checking.
+- Configure deployment infrastructure (e.g., Vercel for frontend, Fly.io/Render for backend).

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,44 @@
+# Backend service
+
+This directory houses the FastAPI application for the GPT5 Hackathon monorepo. It is structured to scale with feature teams and encourages modular, testable code.
+
+## Getting started
+
+```bash
+cd backend
+poetry install
+poetry run uvicorn app.main:app --reload
+```
+
+Visit `http://localhost:8000/docs` for interactive API documentation.
+
+## Project layout
+
+```
+backend/
+├── app/
+│   ├── api/
+│   │   ├── __init__.py
+│   │   ├── dependencies.py
+│   │   └── routes.py
+│   ├── core/
+│   │   └── config.py
+│   ├── models/
+│   │   └── __init__.py
+│   ├── schemas/
+│   │   └── health.py
+│   ├── services/
+│   │   └── __init__.py
+│   └── main.py
+├── tests/
+│   └── test_health.py
+└── pyproject.toml
+```
+
+Each layer has a clear responsibility:
+
+- **core** — application-wide configuration.
+- **api** — routers, dependencies, and view logic.
+- **schemas** — Pydantic models for request/response validation.
+- **services** — business logic that can be shared across routers.
+- **tests** — pytest-based integration/unit tests.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+"""Application package for the FastAPI service."""

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,0 +1,5 @@
+"""API routers exposed by the FastAPI application."""
+
+from .routes import router
+
+__all__ = ["router"]

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -1,0 +1,7 @@
+from app.core.config import Settings, get_settings as _get_settings
+
+
+def get_settings() -> Settings:
+    """Dependency wrapper for injecting cached settings into routes."""
+
+    return _get_settings()

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, Depends
+
+from app.api.dependencies import get_settings
+from app.core.config import Settings
+from app.schemas.health import HealthResponse
+
+router = APIRouter()
+
+
+@router.get("/health", response_model=HealthResponse, tags=["health"])
+async def health_check(settings: Settings = Depends(get_settings)) -> HealthResponse:
+    """Return basic service health information."""
+
+    return HealthResponse(
+        status="ok",
+        service=settings.project_name,
+        environment=settings.environment,
+    )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,0 +1,23 @@
+from functools import lru_cache
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Application configuration managed via environment variables."""
+
+    project_name: str = Field(default="GPT5 Hackathon API", alias="PROJECT_NAME")
+    api_v1_prefix: str = Field(default="/api/v1", alias="API_V1_PREFIX")
+    environment: str = Field(default="development", alias="ENVIRONMENT")
+
+    model_config = {
+        "env_file": ".env",
+        "case_sensitive": False,
+    }
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return cached application settings."""
+
+    return Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,26 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.api import routes
+from app.core.config import get_settings
+
+settings = get_settings()
+
+app = FastAPI(title=settings.project_name)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(routes.router, prefix=settings.api_v1_prefix)
+
+
+@app.get("/", tags=["root"])
+async def root() -> dict[str, str]:
+    """Root route useful for uptime checks."""
+
+    return {"message": "Welcome to the GPT5 Hackathon API"}

--- a/backend/app/schemas/health.py
+++ b/backend/app/schemas/health.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+
+class HealthResponse(BaseModel):
+    status: str
+    service: str
+    environment: str

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,25 @@
+[tool.poetry]
+name = "backend"
+version = "0.1.0"
+description = "FastAPI service for the GPT5 Hackathon monorepo"
+authors = ["GPT5 Team <team@example.com>"]
+readme = "README.md"
+packages = [{ include = "app" }]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+fastapi = "^0.111.0"
+uvicorn = { extras = ["standard"], version = "^0.29.0" }
+pydantic = "^2.7.1"
+pydantic-settings = "^2.2.1"
+python-dotenv = "^1.0.1"
+
+[tool.poetry.group.dev.dependencies]
+black = "^24.4.2"
+ruff = "^0.4.8"
+pytest = "^8.2.1"
+httpx = "^0.27.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,15 @@
+import pytest
+from httpx import AsyncClient
+
+from app.main import app
+
+
+@pytest.mark.anyio
+async def test_health_endpoint_returns_ok() -> None:
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        response = await client.get("/api/v1/health")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["service"] == "GPT5 Hackathon API"

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  root: true,
+  extends: ["next/core-web-vitals"],
+  parserOptions: {
+    project: true
+  },
+  rules: {
+    "@next/next/no-img-element": "off"
+  }
+};

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,28 @@
+# Frontend application
+
+This Next.js application is configured for rapid UI development with Tailwind CSS, Radix Themes, shadcn-style primitives, and Framer Motion animations.
+
+## Available scripts
+
+```bash
+pnpm dev      # Start the development server
+pnpm build    # Create a production build
+pnpm start    # Serve the production build
+pnpm lint     # Run ESLint
+pnpm format   # Format with Prettier
+```
+
+## Project layout
+
+```
+frontend/
+├── app/              # App Router routes
+├── components/       # Reusable UI primitives and providers
+├── lib/              # Shared utilities (e.g., fonts, helpers)
+├── public/           # Static assets
+├── tailwind.config.ts
+├── tsconfig.json
+└── package.json
+```
+
+Fonts from Inter, Manrope, and IBM Plex Sans are preloaded via `next/font`. To use additional brand fonts, add the assets to `public/` and update `lib/fonts.ts` accordingly.

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,0 +1,25 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+html,
+body {
+  min-height: 100%;
+  scroll-behavior: smooth;
+  background-color: #f8fafc;
+}
+
+body {
+  font-family: var(--font-inter), system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  color: #0f172a;
+}
+
+.dark body {
+  background-color: #020617;
+  color: #e2e8f0;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,32 @@
+import "./globals.css";
+
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { ThemeProvider } from "@/components/theme-provider";
+import { inter, manrope, plexSans } from "@/lib/fonts";
+
+export const metadata: Metadata = {
+  title: {
+    default: "GPT5 Hackathon Starter",
+    template: "%s | GPT5 Hackathon"
+  },
+  description: "A modern monorepo starter with Next.js and FastAPI."
+};
+
+export default function RootLayout({
+  children
+}: Readonly<{ children: ReactNode }>) {
+  return (
+    <html
+      lang="en"
+      className={`antialiased ${inter.variable} ${manrope.variable} ${plexSans.variable}`}
+      suppressHydrationWarning
+    >
+      <body>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          {children}
+        </ThemeProvider>
+      </body>
+    </html>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState, type SVGProps } from "react";
+import { motion } from "framer-motion";
+import { SunIcon } from "@radix-ui/react-icons";
+import { Theme, Flex, Heading, Text } from "@radix-ui/themes";
+import "@radix-ui/themes/styles.css";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const heroVariants = {
+  hidden: { opacity: 0, y: 16 },
+  visible: { opacity: 1, y: 0 }
+};
+
+export default function HomePage() {
+  const [clicks, setClicks] = useState(0);
+
+  return (
+    <Theme appearance="inherit">
+      <main className="mx-auto flex min-h-screen w-full max-w-5xl flex-col gap-16 px-6 py-24">
+        <motion.section
+          variants={heroVariants}
+          initial="hidden"
+          animate="visible"
+          transition={{ duration: 0.5, ease: "easeOut" }}
+          className="space-y-6"
+        >
+          <span className="inline-flex items-center gap-2 rounded-full bg-slate-200 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600 dark:bg-slate-800 dark:text-slate-200">
+            <SunIcon className="h-4 w-4" />
+            Fast foundations
+          </span>
+          <Heading as="h1" size="8" className="font-heading text-balance text-4xl md:text-5xl">
+            Ship modern product experiences with confidence.
+          </Heading>
+          <Text as="p" size="4" className="max-w-2xl text-lg text-slate-600 dark:text-slate-300">
+            This monorepo pairs a type-safe Next.js frontend with a FastAPI backend so
+            that teams can iterate quickly without sacrificing best practices. Tailwind
+            CSS, shadcn/ui patterns, and Radix Themes are ready for you to build on.
+          </Text>
+          <Flex gap="3" wrap="wrap">
+            <Button onClick={() => setClicks((count) => count + 1)}>Primary action</Button>
+            <Button variant="outline" onClick={() => setClicks(0)}>
+              Reset clicks ({clicks})
+            </Button>
+          </Flex>
+        </motion.section>
+        <section className="grid gap-6 md:grid-cols-2">
+          {features.map((feature) => (
+            <motion.article
+              key={feature.title}
+              className={cn(
+                "rounded-2xl border border-slate-200 bg-white/70 p-6 shadow-sm backdrop-blur dark:border-slate-800 dark:bg-slate-900/50"
+              )}
+              variants={heroVariants}
+              initial="hidden"
+              whileInView="visible"
+              viewport={{ once: true, amount: 0.3 }}
+              transition={{ duration: 0.4, delay: feature.delay }}
+            >
+              <feature.icon className="mb-4 h-8 w-8 text-brand" />
+              <Heading as="h3" size="5" className="mb-2 font-heading">
+                {feature.title}
+              </Heading>
+              <Text as="p" size="3" className="text-slate-600 dark:text-slate-300">
+                {feature.description}
+              </Text>
+            </motion.article>
+          ))}
+        </section>
+      </main>
+    </Theme>
+  );
+}
+
+type Feature = {
+  title: string;
+  description: string;
+  icon: (props: SVGProps<SVGSVGElement>) => JSX.Element;
+  delay: number;
+};
+
+const features: Feature[] = [
+  {
+    title: "Component-driven UI",
+    description:
+      "Tailwind CSS, Radix Themes, and shadcn-style primitives provide a cohesive design system that scales with your product.",
+    icon: (props) => (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" {...props}>
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 6v6l3.5 2.1M4 6h16M4 10h4m12 8H4"
+        />
+      </svg>
+    ),
+    delay: 0.1
+  },
+  {
+    title: "API first backend",
+    description:
+      "FastAPI comes configured with modular routers, typed models, and first-class async support for building reliable services.",
+    icon: (props) => (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" {...props}>
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M4 7h16M4 12h8m-8 5h12"
+        />
+      </svg>
+    ),
+    delay: 0.2
+  },
+  {
+    title: "Production-ready DX",
+    description:
+      "Opinionated tooling including ESLint, Prettier, and TypeScript keeps your codebase consistent across contributors.",
+    icon: (props) => (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="m6 9 6 6 6-6" />
+      </svg>
+    ),
+    delay: 0.3
+  },
+  {
+    title: "Animations built-in",
+    description:
+      "Framer Motion is wired up so you can focus on delightful interactions instead of boilerplate integration work.",
+    icon: (props) => (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" {...props}>
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M4 12c1.5-4 4.5-6 8-6s6.5 2 8 6c-1.5 4-4.5 6-8 6s-6.5-2-8-6z"
+        />
+      </svg>
+    ),
+    delay: 0.4
+  }
+];

--- a/frontend/components/theme-provider.tsx
+++ b/frontend/components/theme-provider.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import * as React from "react";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+export type ThemeProviderProps = React.ComponentProps<typeof NextThemesProvider>;
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-brand text-brand-foreground hover:bg-slate-800",
+        outline: "border border-slate-200 bg-transparent text-brand hover:bg-slate-100",
+        ghost: "bg-transparent text-brand hover:bg-slate-100"
+      },
+      size: {
+        sm: "h-9 px-3",
+        md: "h-10 px-4",
+        lg: "h-11 px-6",
+        icon: "h-10 w-10"
+      }
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "md"
+    }
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size }), className)}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";

--- a/frontend/lib/fonts.ts
+++ b/frontend/lib/fonts.ts
@@ -1,0 +1,19 @@
+import { IBM_Plex_Sans, Inter, Manrope } from "next/font/google";
+
+export const inter = Inter({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-inter"
+});
+
+export const manrope = Manrope({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-manrope"
+});
+
+export const plexSans = IBM_Plex_Sans({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-plex"
+});

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "format": "prettier --write ."
+  },
+  "dependencies": {
+    "@radix-ui/react-icons": "^1.3.0",
+    "@radix-ui/themes": "^3.0.4",
+    "@tailwindcss/typography": "^0.5.13",
+    "@tanstack/react-query": "^5.45.0",
+    "@types/node": "^20.14.2",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.16",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "framer-motion": "^11.0.14",
+    "lucide-react": "^0.420.0",
+    "material-symbols": "^0.14.0",
+    "next": "^14.2.5",
+    "next-themes": "^0.3.0",
+    "postcss": "^8.4.38",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "tailwind-merge": "^2.2.1",
+    "tailwindcss": "^3.4.4",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.5",
+    "prettier": "^3.3.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/frontend/public/README.md
+++ b/frontend/public/README.md
@@ -1,0 +1,3 @@
+# Public assets
+
+Place static assets such as images, icons, and custom font files in this directory. Files stored here are served at the root of the Next.js application.

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,29 @@
+import type { Config } from "tailwindcss";
+import { fontFamily } from "tailwindcss/defaultTheme";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./lib/**/*.{ts,tsx}",
+    "./node_modules/@radix-ui/themes/dist/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ["var(--font-inter)", ...fontFamily.sans],
+        heading: ["var(--font-plex)", "var(--font-manrope)", ...fontFamily.sans]
+      },
+      colors: {
+        brand: {
+          DEFAULT: "#0F172A",
+          foreground: "#F8FAFC"
+        }
+      }
+    }
+  },
+  plugins: [require("@tailwindcss/typography")]
+};
+
+export default config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js 14 frontend with Tailwind CSS, Radix Themes, shadcn-style button component, and shared utilities
- configure FastAPI backend with modular routers, Pydantic schemas, settings management, and starter health test
- document repo layout, setup steps, and team workflows for collaborating across apps

## Testing
- not run (infrastructure only)


------
https://chatgpt.com/codex/tasks/task_e_68d803569e4c8332a6b2fcf7cf5dea2e