### PR TITLE
Add multimodal emotion analysis pipeline

### DIFF
--- a/agent-decisions/emotion-pipeline.md
+++ b/agent-decisions/emotion-pipeline.md
@@ -1,0 +1,44 @@
+# Multi-modal Emotion Analysis Design Decisions
+
+## Emotion taxonomy selection
+
+- **Chosen taxonomy:** Plutchik's primary emotions (joy, trust, fear, surprise, sadness, disgust, anger, anticipation) plus a neutral state.
+- **Rationale:**
+  - Plutchik's wheel is widely referenced across speech, facial expression, and textual affect research, which makes it easier to align heuristic signals from heterogeneous modalities.
+  - The taxonomy balances granularity and interpretability—eight discrete emotions cover common affective states without overwhelming end users in a live dashboard.
+  - Each emotion pair has an intuitive opposite (e.g., joy–sadness), which simplifies fusion logic because modal cues can be mapped using mirrored heuristics.
+  - Existing datasets for speech prosody, sentiment lexicons, and facial action units often annotate according to Plutchik categories, so future upgrades to learned models can use the same schema.
+
+## Backend architecture
+
+- Introduced an `EmotionAnalyzer` service that orchestrates per-modality analyzers (`TextEmotionAnalyzer`, `VoiceEmotionAnalyzer`, and `VideoEmotionAnalyzer`).
+- Created lightweight heuristics for each modality:
+  - **Text:** keyword lexicon and simple sentiment markers to bias probabilities.
+  - **Voice:** thresholds over energy, pitch, tempo, and jitter to approximate arousal/valence cues.
+  - **Video:** normalized facial landmark features (smile ratio, eyebrow raise, eye openness, head movement).
+- Implemented a fusion layer that re-weights available modalities (default 0.4 text / 0.3 voice / 0.3 video) and normalizes to a probability distribution.
+- Added FastAPI endpoint `POST /api/v1/emotion/analyze` returning dominant emotion, confidence, aggregated probabilities, modality-specific breakdown, and the weights that participated.
+
+## Frontend architecture
+
+- Replaced the landing page with a live "emotion console" that:
+  - Requests camera and microphone access and streams the media locally.
+  - Extracts audio features (RMS energy, estimated pitch via autocorrelation, zero-crossing tempo, jitter) in real time using the Web Audio API.
+  - Loads MediaPipe FaceMesh through `@tensorflow-models/face-landmarks-detection` to compute facial feature ratios for smile intensity, eyebrow raise, eye openness, and head movement.
+  - Allows users to supply text transcripts via a textarea that is bundled with each inference window.
+  - Sends aggregated features to the backend every three seconds and visualizes the fused probabilities and per-modality contributions.
+- Included responsive UI cards so users can inspect raw signal metrics alongside the predicted taxonomy scores.
+
+## Data flow summary
+
+1. **Capture layer (frontend):** Acquire webcam/audio streams, compute normalized feature vectors, and collect optional text transcript.
+2. **Transport:** Batch the latest features into a JSON payload and call the FastAPI endpoint on a rolling interval.
+3. **Service layer (backend):** Each modality analyzer produces a probability distribution across the Plutchik emotions; missing modalities are ignored.
+4. **Fusion:** Weighted averages yield the overall distribution. The dominant emotion and confidence are surfaced back to the client.
+5. **Presentation:** The UI updates live charts for aggregated predictions and modality-specific contributions, allowing quick diagnosis of which signals drove the decision.
+
+## Future enhancements
+
+- Swap heuristic analyzers with learned models (e.g., fine-tuned transformers for text, spectral CNNs for audio) without changing the API contract.
+- Introduce calibration routines so users can personalize baseline thresholds (e.g., average pitch) for more accurate detections.
+- Persist session timelines to visualize emotion trends and support historical analytics.

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -1,7 +1,23 @@
+from functools import lru_cache
+
 from app.core.config import Settings, get_settings as _get_settings
+from app.services.emotion import EmotionAnalyzer
 
 
 def get_settings() -> Settings:
     """Dependency wrapper for injecting cached settings into routes."""
 
     return _get_settings()
+
+
+@lru_cache
+def _get_emotion_analyzer() -> EmotionAnalyzer:
+    """Return a singleton instance of the emotion analyzer."""
+
+    return EmotionAnalyzer()
+
+
+def get_emotion_analyzer() -> EmotionAnalyzer:
+    """FastAPI dependency that reuses the analyzer instance."""
+
+    return _get_emotion_analyzer()

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter, Depends
 
-from app.api.dependencies import get_settings
+from app.api.dependencies import get_emotion_analyzer, get_settings
 from app.core.config import Settings
+from app.schemas.emotion import EmotionAnalysisRequest, EmotionAnalysisResponse
 from app.schemas.health import HealthResponse
+from app.services.emotion import EmotionAnalyzer
 
 router = APIRouter()
 
@@ -16,3 +18,13 @@ async def health_check(settings: Settings = Depends(get_settings)) -> HealthResp
         service=settings.project_name,
         environment=settings.environment,
     )
+
+
+@router.post("/emotion/analyze", response_model=EmotionAnalysisResponse, tags=["emotion"])
+async def analyze_emotion(
+    payload: EmotionAnalysisRequest,
+    analyzer: EmotionAnalyzer = Depends(get_emotion_analyzer),
+) -> EmotionAnalysisResponse:
+    """Analyze multi-modal signals and return an emotion profile."""
+
+    return analyzer.analyze(payload)

--- a/backend/app/schemas/emotion.py
+++ b/backend/app/schemas/emotion.py
@@ -1,0 +1,72 @@
+"""Pydantic schemas for emotion analysis endpoints."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping
+
+from pydantic import BaseModel, Field
+
+
+class VoiceSignal(BaseModel):
+    """Acoustic features extracted from a voice stream."""
+
+    energy: float = Field(ge=0, description="Root-mean-square energy level of the audio segment.")
+    pitch: float = Field(ge=0, description="Dominant fundamental frequency in Hertz.")
+    tempo: float = Field(
+        ge=0,
+        description="Approximate syllable rate (words per second derived from zero-crossing heuristics).",
+    )
+    jitter: float = Field(
+        ge=0,
+        description="Short-term pitch stability estimate (0-1, higher means less stable).",
+    )
+    confidence: float | None = Field(
+        default=None,
+        ge=0,
+        le=1,
+        description="Optional indicator of how reliable the acoustic features are.",
+    )
+
+
+class VideoSignal(BaseModel):
+    """Lightweight facial expression features extracted on-device."""
+
+    smile: float = Field(ge=0, le=1, description="Normalized smile intensity.")
+    brow_raise: float = Field(ge=0, le=1, description="Degree of eyebrow elevation.")
+    eye_openness: float = Field(ge=0, le=1, description="Average openness of both eyes.")
+    head_movement: float = Field(ge=0, le=1, description="Magnitude of recent head movement.")
+    engagement: float | None = Field(
+        default=None,
+        ge=0,
+        le=1,
+        description="Optional heuristic describing how attentive the participant is.",
+    )
+
+
+class EmotionAnalysisRequest(BaseModel):
+    """Payload combining text, voice, and video observations."""
+
+    text: str | None = Field(default=None, description="Text transcript for the analyzed window.")
+    voice: VoiceSignal | None = Field(default=None, description="Aggregated acoustic measurements.")
+    video: VideoSignal | None = Field(default=None, description="Facial expression measurements.")
+    metadata: Dict[str, Any] | None = Field(default=None, description="Arbitrary client metadata.")
+
+
+class ModalityBreakdown(BaseModel):
+    """Probability distributions per modality."""
+
+    text: Mapping[str, float] | None = None
+    voice: Mapping[str, float] | None = None
+    video: Mapping[str, float] | None = None
+
+
+class EmotionAnalysisResponse(BaseModel):
+    """Unified emotion estimate returned to clients."""
+
+    taxonomy: str
+    dominant_emotion: str
+    confidence: float = Field(ge=0, le=1)
+    aggregated: Mapping[str, float]
+    modality_breakdown: ModalityBreakdown
+    modality_weights: Mapping[str, float]
+

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,5 @@
+"""Service layer exports."""
+
+from .emotion import EmotionAnalyzer, EmotionTaxonomy
+
+__all__ = ["EmotionAnalyzer", "EmotionTaxonomy"]

--- a/backend/app/services/emotion.py
+++ b/backend/app/services/emotion.py
@@ -1,0 +1,352 @@
+"""Emotion analysis services that fuse multi-modal signals."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Iterable, Mapping, MutableMapping
+
+from app.schemas.emotion import (
+    EmotionAnalysisRequest,
+    EmotionAnalysisResponse,
+    ModalityBreakdown,
+    VideoSignal,
+    VoiceSignal,
+)
+
+
+class EmotionTaxonomy(str, Enum):
+    """Supported emotion taxonomies."""
+
+    PLUTCHIK_PRIMARY = "plutchik_primary"
+
+
+PLUTCHIK_EMOTIONS: tuple[str, ...] = (
+    "joy",
+    "trust",
+    "fear",
+    "surprise",
+    "sadness",
+    "disgust",
+    "anger",
+    "anticipation",
+    "neutral",
+)
+
+
+def _normalized(scores: Mapping[str, float], *, epsilon: float = 1e-6) -> Dict[str, float]:
+    """Return scores normalized to a probability distribution."""
+
+    total = float(sum(max(value, 0.0) for value in scores.values()))
+    if total <= epsilon:
+        uniform = 1.0 / len(scores)
+        return {emotion: uniform for emotion in scores}
+    return {emotion: max(value, 0.0) / total for emotion, value in scores.items()}
+
+
+def _ensure_emotion_keys(scores: Mapping[str, float], emotions: Iterable[str]) -> Dict[str, float]:
+    """Ensure all expected emotion keys exist in the mapping."""
+
+    return {emotion: float(scores.get(emotion, 0.0)) for emotion in emotions}
+
+
+class TextEmotionAnalyzer:
+    """Lexicon-driven heuristics for inferring emotion from text transcripts."""
+
+    KEYWORD_LEXICON: Mapping[str, set[str]] = {
+        "joy": {
+            "happy",
+            "glad",
+            "excited",
+            "delighted",
+            "grateful",
+            "pleased",
+            "smile",
+            "fantastic",
+        },
+        "trust": {
+            "confident",
+            "assured",
+            "certain",
+            "secure",
+            "reliable",
+            "support",
+            "together",
+        },
+        "fear": {
+            "afraid",
+            "worried",
+            "scared",
+            "anxious",
+            "terrified",
+            "nervous",
+            "panic",
+        },
+        "surprise": {
+            "surprised",
+            "shocked",
+            "amazed",
+            "astonished",
+            "wow",
+            "unexpected",
+        },
+        "sadness": {
+            "sad",
+            "upset",
+            "down",
+            "depressed",
+            "unhappy",
+            "cry",
+            "mourn",
+        },
+        "disgust": {
+            "gross",
+            "disgusted",
+            "nasty",
+            "repulsed",
+            "abhorrent",
+            "yuck",
+        },
+        "anger": {
+            "angry",
+            "furious",
+            "mad",
+            "enraged",
+            "annoyed",
+            "resent",
+        },
+        "anticipation": {
+            "looking",
+            "ready",
+            "planning",
+            "awaiting",
+            "expect",
+            "soon",
+            "hope",
+        },
+    }
+
+    def analyze(self, text: str | None) -> Dict[str, float] | None:
+        """Return normalized emotion probabilities for textual content."""
+
+        if not text or not text.strip():
+            return None
+
+        import re
+
+        tokens = re.findall(r"\b\w+\b", text.lower())
+        if not tokens:
+            return None
+
+        scores: MutableMapping[str, float] = {emotion: 0.0 for emotion in PLUTCHIK_EMOTIONS}
+        punctuation_bonus = text.count("!") * 0.2
+        question_bonus = text.count("?") * 0.1
+
+        for token in tokens:
+            for emotion, keywords in self.KEYWORD_LEXICON.items():
+                if token in keywords:
+                    scores[emotion] += 1.0
+
+        if punctuation_bonus:
+            scores["surprise"] += punctuation_bonus
+        if question_bonus:
+            scores["anticipation"] += question_bonus
+
+        sentiment_bias = 0.0
+        positive_markers = {"good", "great", "love", "awesome", "yes"}
+        negative_markers = {"no", "bad", "hate", "awful", "never"}
+        for token in tokens:
+            if token in positive_markers:
+                sentiment_bias += 0.5
+            if token in negative_markers:
+                sentiment_bias -= 0.5
+
+        if sentiment_bias > 0:
+            scores["joy"] += sentiment_bias
+            scores["trust"] += sentiment_bias * 0.5
+        elif sentiment_bias < 0:
+            scores["sadness"] += abs(sentiment_bias)
+            scores["anger"] += abs(sentiment_bias) * 0.5
+
+        neutral_floor = max(len(tokens) * 0.05, 0.2)
+        scores["neutral"] = max(scores["neutral"], neutral_floor)
+
+        return _normalized(_ensure_emotion_keys(scores, PLUTCHIK_EMOTIONS))
+
+
+@dataclass(slots=True)
+class VoiceBands:
+    """Threshold configuration for mapping acoustic features to emotions."""
+
+    calm_energy: float = 0.08
+    elevated_energy: float = 0.18
+    high_pitch: float = 220.0
+    low_pitch: float = 140.0
+    rapid_tempo: float = 2.8
+    slow_tempo: float = 1.4
+    jitter_threshold: float = 0.15
+
+
+class VoiceEmotionAnalyzer:
+    """Heuristic analysis using common prosodic indicators."""
+
+    def __init__(self, bands: VoiceBands | None = None) -> None:
+        self.bands = bands or VoiceBands()
+
+    def analyze(self, signal: VoiceSignal | None) -> Dict[str, float] | None:
+        if signal is None:
+            return None
+
+        scores: MutableMapping[str, float] = {emotion: 0.0 for emotion in PLUTCHIK_EMOTIONS}
+
+        energy = max(signal.energy, 0.0)
+        pitch = max(signal.pitch, 0.0)
+        tempo = max(signal.tempo, 0.0)
+        jitter = max(signal.jitter, 0.0)
+
+        if energy <= self.bands.calm_energy:
+            scores["sadness"] += 1.2
+            scores["neutral"] += 0.8
+        elif energy >= self.bands.elevated_energy:
+            scores["anger"] += 1.0
+            scores["joy"] += 0.7
+            scores["surprise"] += 0.5
+        else:
+            scores["trust"] += 0.6
+            scores["anticipation"] += 0.4
+
+        if pitch >= self.bands.high_pitch:
+            scores["surprise"] += 1.0
+            scores["fear"] += 0.8
+        elif pitch <= self.bands.low_pitch:
+            scores["sadness"] += 0.6
+            scores["disgust"] += 0.3
+        else:
+            scores["trust"] += 0.3
+
+        if tempo >= self.bands.rapid_tempo:
+            scores["anticipation"] += 0.9
+            scores["anger"] += 0.4
+        elif tempo <= self.bands.slow_tempo:
+            scores["sadness"] += 0.5
+            scores["fear"] += 0.3
+
+        if jitter >= self.bands.jitter_threshold:
+            scores["fear"] += 1.1
+            scores["surprise"] += 0.4
+        else:
+            scores["trust"] += 0.2
+
+        scores["neutral"] += 0.5
+
+        return _normalized(_ensure_emotion_keys(scores, PLUTCHIK_EMOTIONS))
+
+
+class VideoEmotionAnalyzer:
+    """Interpret facial cues derived from a lightweight landmark model."""
+
+    def analyze(self, signal: VideoSignal | None) -> Dict[str, float] | None:
+        if signal is None:
+            return None
+
+        scores: MutableMapping[str, float] = {emotion: 0.0 for emotion in PLUTCHIK_EMOTIONS}
+
+        smile = max(min(signal.smile, 1.0), 0.0)
+        brow_raise = max(min(signal.brow_raise, 1.0), 0.0)
+        eye_openness = max(min(signal.eye_openness, 1.0), 0.0)
+        head_movement = max(min(signal.head_movement, 1.0), 0.0)
+        engagement = max(min(signal.engagement or 0.0, 1.0), 0.0)
+
+        scores["joy"] += smile * 1.4
+        scores["trust"] += smile * 0.5
+        scores["anticipation"] += engagement * 0.6
+
+        scores["surprise"] += brow_raise * 1.0 + eye_openness * 0.6
+        scores["fear"] += brow_raise * 0.5 + head_movement * 0.7
+
+        scores["anger"] += (1.0 - smile) * engagement * 0.5
+        scores["disgust"] += max(0.0, engagement - smile) * 0.3
+
+        calmness = max(0.0, 1.0 - (brow_raise + head_movement) / 2.0)
+        scores["neutral"] += calmness * 0.8
+        scores["sadness"] += (1.0 - smile) * (1.0 - eye_openness) * 0.8
+
+        return _normalized(_ensure_emotion_keys(scores, PLUTCHIK_EMOTIONS))
+
+
+class EmotionFusion:
+    """Combine modality-specific probabilities into a single prediction."""
+
+    DEFAULT_WEIGHTS: Mapping[str, float] = {
+        "text": 0.4,
+        "voice": 0.3,
+        "video": 0.3,
+    }
+
+    def __init__(self, emotions: Iterable[str]) -> None:
+        self.emotions = tuple(emotions)
+
+    def combine(self, modality_scores: Mapping[str, Dict[str, float] | None]) -> tuple[Dict[str, float], Dict[str, float]]:
+        available = {modality: scores for modality, scores in modality_scores.items() if scores}
+        if not available:
+            uniform = {emotion: 1.0 / len(self.emotions) for emotion in self.emotions}
+            return uniform, {}
+
+        total_weight = sum(self.DEFAULT_WEIGHTS.get(modality, 0.0) for modality in available)
+        if total_weight == 0:
+            total_weight = len(available)
+            weights = {modality: 1.0 / len(available) for modality in available}
+        else:
+            weights = {
+                modality: self.DEFAULT_WEIGHTS.get(modality, 0.0) / total_weight
+                for modality in available
+            }
+
+        aggregated = {emotion: 0.0 for emotion in self.emotions}
+        for modality, scores in available.items():
+            weighted = weights[modality]
+            for emotion in self.emotions:
+                aggregated[emotion] += weighted * scores.get(emotion, 0.0)
+
+        return _normalized(aggregated), weights
+
+
+class EmotionAnalyzer:
+    """Facade that orchestrates modality-level analyzers."""
+
+    def __init__(self, taxonomy: EmotionTaxonomy = EmotionTaxonomy.PLUTCHIK_PRIMARY) -> None:
+        if taxonomy != EmotionTaxonomy.PLUTCHIK_PRIMARY:
+            msg = f"Unsupported taxonomy: {taxonomy}"
+            raise ValueError(msg)
+
+        self.taxonomy = taxonomy
+        self.text_analyzer = TextEmotionAnalyzer()
+        self.voice_analyzer = VoiceEmotionAnalyzer()
+        self.video_analyzer = VideoEmotionAnalyzer()
+        self.fusion = EmotionFusion(PLUTCHIK_EMOTIONS)
+
+    def analyze(self, payload: EmotionAnalysisRequest) -> EmotionAnalysisResponse:
+        text_scores = self.text_analyzer.analyze(payload.text)
+        voice_scores = self.voice_analyzer.analyze(payload.voice)
+        video_scores = self.video_analyzer.analyze(payload.video)
+
+        aggregated, weights = self.fusion.combine(
+            {
+                "text": text_scores,
+                "voice": voice_scores,
+                "video": video_scores,
+            }
+        )
+
+        dominant = max(aggregated.items(), key=lambda pair: pair[1])
+        modality_breakdown = ModalityBreakdown(text=text_scores, voice=voice_scores, video=video_scores)
+
+        return EmotionAnalysisResponse(
+            taxonomy=self.taxonomy.value,
+            dominant_emotion=dominant[0],
+            confidence=dominant[1],
+            aggregated=aggregated,
+            modality_breakdown=modality_breakdown,
+            modality_weights=weights,
+        )
+

--- a/backend/tests/test_emotion.py
+++ b/backend/tests/test_emotion.py
@@ -1,0 +1,50 @@
+"""Tests for the emotion analysis service and API."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.schemas.emotion import EmotionAnalysisRequest, VideoSignal, VoiceSignal
+from app.services.emotion import EmotionAnalyzer
+
+
+def test_emotion_analyzer_combines_modalities() -> None:
+    analyzer = EmotionAnalyzer()
+    payload = EmotionAnalysisRequest(
+        text="I am so excited and happy to see everyone!",
+        voice=VoiceSignal(energy=0.25, pitch=250.0, tempo=3.2, jitter=0.05),
+        video=VideoSignal(smile=0.9, brow_raise=0.4, eye_openness=0.6, head_movement=0.2, engagement=0.8),
+    )
+
+    result = analyzer.analyze(payload)
+
+    assert result.dominant_emotion in result.aggregated
+    assert 0 <= result.confidence <= 1
+    assert pytest.approx(sum(result.aggregated.values()), rel=1e-3) == 1.0
+    assert result.modality_breakdown.text is not None
+    assert result.modality_breakdown.voice is not None
+    assert result.modality_breakdown.video is not None
+
+
+def test_emotion_endpoint_returns_prediction() -> None:
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v1/emotion/analyze",
+            json={
+                "text": "The news makes me anxious but I'm hopeful",
+                "voice": {"energy": 0.12, "pitch": 210.0, "tempo": 2.1, "jitter": 0.2},
+                "video": {
+                    "smile": 0.3,
+                    "brow_raise": 0.6,
+                    "eye_openness": 0.5,
+                    "head_movement": 0.4,
+                    "engagement": 0.7,
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["taxonomy"] == "plutchik_primary"
+    assert isinstance(payload["aggregated"], dict)
+    assert payload["dominant_emotion"] in payload["aggregated"]

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,13 +1,11 @@
-import pytest
-from httpx import AsyncClient
+from fastapi.testclient import TestClient
 
 from app.main import app
 
 
-@pytest.mark.anyio
-async def test_health_endpoint_returns_ok() -> None:
-    async with AsyncClient(app=app, base_url="http://test") as client:
-        response = await client.get("/api/v1/health")
+def test_health_endpoint_returns_ok() -> None:
+    with TestClient(app) as client:
+        response = client.get("/api/v1/health")
 
     assert response.status_code == 200
     payload = response.json()

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,141 +1,723 @@
 "use client";
 
-import { useState, type SVGProps } from "react";
-import { motion } from "framer-motion";
-import { SunIcon } from "@radix-ui/react-icons";
-import { Theme, Flex, Heading, Text } from "@radix-ui/themes";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Theme, Heading, Text } from "@radix-ui/themes";
 import "@radix-ui/themes/styles.css";
 
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 
-const heroVariants = {
-  hidden: { opacity: 0, y: 16 },
-  visible: { opacity: 1, y: 0 }
+type EmotionProbabilities = Record<string, number>;
+
+type EmotionAnalysisResponse = {
+  taxonomy: string;
+  dominant_emotion: string;
+  confidence: number;
+  aggregated: EmotionProbabilities;
+  modality_breakdown: {
+    text?: EmotionProbabilities | null;
+    voice?: EmotionProbabilities | null;
+    video?: EmotionProbabilities | null;
+  };
+  modality_weights: Record<string, number>;
 };
 
-export default function HomePage() {
-  const [clicks, setClicks] = useState(0);
+type VoiceSnapshot = {
+  energy: number;
+  pitch: number;
+  tempo: number;
+  jitter: number;
+  confidence: number;
+};
+
+type VideoSnapshot = {
+  smile: number;
+  browRaise: number;
+  eyeOpenness: number;
+  headMovement: number;
+  engagement: number;
+};
+
+type FaceLandmarksDetector = {
+  estimateFaces: (
+    input: HTMLVideoElement,
+    config?: { flipHorizontal?: boolean }
+  ) => Promise<Array<{ keypoints: Array<{ x: number; y: number }> }>>;
+  close: () => Promise<void>;
+};
+
+type FaceLandmarksModule = {
+  createDetector: (
+    model: unknown,
+    config: {
+      runtime: "mediapipe";
+      refineLandmarks?: boolean;
+      solutionPath?: string;
+    }
+  ) => Promise<FaceLandmarksDetector>;
+  SupportedModels: { MediaPipeFaceMesh: unknown };
+};
+
+type MediapipeModule = {
+  VERSION?: string;
+};
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
+
+const EMOTION_ORDER = [
+  "joy",
+  "trust",
+  "fear",
+  "surprise",
+  "sadness",
+  "disgust",
+  "anger",
+  "anticipation",
+  "neutral"
+];
+
+const EMOTION_COLORS: Record<string, string> = {
+  joy: "bg-amber-400",
+  trust: "bg-emerald-400",
+  fear: "bg-cyan-500",
+  surprise: "bg-indigo-400",
+  sadness: "bg-blue-500",
+  disgust: "bg-lime-500",
+  anger: "bg-rose-500",
+  anticipation: "bg-orange-400",
+  neutral: "bg-slate-400"
+};
+
+const clamp = (value: number, min = 0, max = 1) => Math.min(Math.max(value, min), max);
+
+const autoCorrelate = (buffer: Float32Array, sampleRate: number): number => {
+  const SIZE = buffer.length;
+  const MAX_SAMPLES = Math.floor(SIZE / 2);
+  let bestOffset = -1;
+  let bestCorrelation = 0;
+  let rms = 0;
+  for (let i = 0; i < SIZE; i += 1) {
+    const val = buffer[i];
+    rms += val * val;
+  }
+  rms = Math.sqrt(rms / SIZE);
+  if (rms < 0.01) return 0;
+
+  let lastCorrelation = 1;
+  for (let offset = 1; offset < MAX_SAMPLES; offset += 1) {
+    let correlation = 0;
+    for (let i = 0; i < MAX_SAMPLES; i += 1) {
+      correlation += Math.abs(buffer[i] - buffer[i + offset]);
+    }
+    correlation = 1 - correlation / MAX_SAMPLES;
+    if (correlation > 0.9 && correlation > lastCorrelation) {
+      bestCorrelation = correlation;
+      bestOffset = offset;
+    } else if (correlation < lastCorrelation) {
+      break;
+    }
+    lastCorrelation = correlation;
+  }
+
+  if (bestOffset === -1) {
+    return 0;
+  }
+
+  return sampleRate / bestOffset;
+};
+
+const formatPercent = (value: number) => `${Math.round(value * 100)}%`;
+
+const formatNumber = (value: number, decimals = 2) => value.toFixed(decimals);
+
+export default function EmotionConsole(): JSX.Element {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const audioRafRef = useRef<number>();
+  const videoRafRef = useRef<number>();
+  const pollIntervalRef = useRef<number>();
+  const detectorRef = useRef<FaceLandmarksDetector | null>(null);
+  const voiceFeaturesRef = useRef({
+    energy: 0,
+    pitch: 0,
+    tempo: 0,
+    jitter: 0,
+    confidence: 0,
+    lastPitch: 0,
+    updatedAt: 0
+  });
+  const videoFeaturesRef = useRef({
+    smile: 0,
+    browRaise: 0,
+    eyeOpenness: 0,
+    headMovement: 0,
+    engagement: 0,
+    updatedAt: 0,
+    lastNoseX: 0,
+    lastNoseY: 0
+  });
+  const isRunningRef = useRef(false);
+  const textRef = useRef("");
+  const lastAudioSnapshotRef = useRef(0);
+  const lastVideoSnapshotRef = useRef(0);
+
+  const [isRunning, setIsRunning] = useState(false);
+  const [status, setStatus] = useState<string>("Idle – start a capture session to analyze emotion signals.");
+  const [error, setError] = useState<string | null>(null);
+  const [textInput, setTextInput] = useState("");
+  const [voiceSnapshot, setVoiceSnapshot] = useState<VoiceSnapshot | null>(null);
+  const [videoSnapshot, setVideoSnapshot] = useState<VideoSnapshot | null>(null);
+  const [analysis, setAnalysis] = useState<EmotionAnalysisResponse | null>(null);
+
+  useEffect(() => {
+    textRef.current = textInput;
+  }, [textInput]);
+
+  useEffect(() => {
+    isRunningRef.current = isRunning;
+  }, [isRunning]);
+
+  const cleanup = useCallback(async () => {
+    window.clearInterval(pollIntervalRef.current);
+    cancelAnimationFrame(audioRafRef.current ?? 0);
+    cancelAnimationFrame(videoRafRef.current ?? 0);
+    pollIntervalRef.current = undefined;
+    audioRafRef.current = undefined;
+    videoRafRef.current = undefined;
+
+    if (detectorRef.current) {
+      await detectorRef.current.close();
+      detectorRef.current = null;
+    }
+
+    const analyser = analyserRef.current;
+    analyserRef.current = null;
+    if (analyser) {
+      analyser.disconnect();
+    }
+
+    const audioContext = audioContextRef.current;
+    audioContextRef.current = null;
+    if (audioContext) {
+      await audioContext.close();
+    }
+
+    const stream = mediaStreamRef.current;
+    mediaStreamRef.current = null;
+    stream?.getTracks().forEach((track) => track.stop());
+
+    setVoiceSnapshot(null);
+    setVideoSnapshot(null);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      cleanup().catch(() => undefined);
+    };
+  }, [cleanup]);
+
+  const processAudio = useCallback(() => {
+    const analyser = analyserRef.current;
+    const audioContext = audioContextRef.current;
+    if (!analyser || !audioContext || !isRunningRef.current) {
+      return;
+    }
+
+    const bufferLength = analyser.fftSize;
+    const timeDomain = new Float32Array(bufferLength);
+    analyser.getFloatTimeDomainData(timeDomain);
+
+    let sumSquares = 0;
+    let zeroCrossings = 0;
+    let previousSample = timeDomain[0];
+    for (let i = 0; i < bufferLength; i += 1) {
+      const sample = timeDomain[i];
+      sumSquares += sample * sample;
+      if ((sample >= 0 && previousSample < 0) || (sample < 0 && previousSample >= 0)) {
+        zeroCrossings += 1;
+      }
+      previousSample = sample;
+    }
+
+    const energy = Math.sqrt(sumSquares / bufferLength);
+    const pitch = autoCorrelate(timeDomain, audioContext.sampleRate);
+    const durationSeconds = bufferLength / audioContext.sampleRate;
+    const zeroCrossRate = zeroCrossings / Math.max(durationSeconds, 1e-6);
+    const tempo = clamp(zeroCrossRate / 250, 0, 6);
+
+    const lastPitch = voiceFeaturesRef.current.lastPitch;
+    const jitter = pitch > 0 && lastPitch > 0 ? clamp(Math.abs(pitch - lastPitch) / Math.max(pitch, lastPitch), 0, 1) : 0;
+    const confidence = clamp(energy * 3, 0, 1);
+
+    voiceFeaturesRef.current = {
+      energy,
+      pitch,
+      tempo,
+      jitter,
+      confidence,
+      lastPitch: pitch || lastPitch,
+      updatedAt: Date.now()
+    };
+
+    const now = performance.now();
+    if (now - lastAudioSnapshotRef.current > 250) {
+      lastAudioSnapshotRef.current = now;
+      setVoiceSnapshot({ energy, pitch, tempo, jitter, confidence });
+    }
+
+    audioRafRef.current = requestAnimationFrame(processAudio);
+  }, []);
+
+  const processVideo = useCallback(async () => {
+    if (!detectorRef.current || !isRunningRef.current) {
+      return;
+    }
+
+    const video = videoRef.current;
+    if (!video || video.readyState < 2) {
+      videoRafRef.current = requestAnimationFrame(() => {
+        processVideo().catch(() => undefined);
+      });
+      return;
+    }
+
+    try {
+      const faces = await detectorRef.current.estimateFaces(video, {
+        flipHorizontal: true
+      });
+
+      if (faces.length > 0) {
+        const face = faces[0];
+        const keypoints = face.keypoints;
+
+        const getPoint = (index: number) => keypoints[index];
+        const distance = (aIndex: number, bIndex: number) => {
+          const a = getPoint(aIndex);
+          const b = getPoint(bIndex);
+          const dx = a.x - b.x;
+          const dy = a.y - b.y;
+          return Math.sqrt(dx * dx + dy * dy);
+        };
+
+        const faceWidth = distance(33, 263);
+        const mouthWidth = distance(61, 291);
+        const mouthHeight = distance(13, 14);
+        const smile = clamp((mouthWidth / Math.max(faceWidth, 1e-3) - 0.32) * 5);
+        const eyeLeft = distance(159, 145);
+        const eyeRight = distance(386, 374);
+        const eyeOpenness = clamp(((eyeLeft + eyeRight) / 2 / Math.max(faceWidth, 1e-3) - 0.025) * 18);
+        const browLeft = distance(70, 159);
+        const browRight = distance(300, 386);
+        const browRaise = clamp(((browLeft + browRight) / 2 / Math.max(faceWidth, 1e-3) - 0.05) * 12);
+
+        const nose = getPoint(1);
+        const lastNoseX = videoFeaturesRef.current.lastNoseX;
+        const lastNoseY = videoFeaturesRef.current.lastNoseY;
+        const movement = Math.sqrt((nose.x - lastNoseX) ** 2 + (nose.y - lastNoseY) ** 2);
+        const headMovement = clamp(movement * 60);
+
+        const engagement = clamp((smile + browRaise + eyeOpenness + headMovement) / 4);
+
+        videoFeaturesRef.current = {
+          smile,
+          browRaise,
+          eyeOpenness,
+          headMovement,
+          engagement,
+          updatedAt: Date.now(),
+          lastNoseX: nose.x,
+          lastNoseY: nose.y
+        };
+
+        const now = performance.now();
+        if (now - lastVideoSnapshotRef.current > 250) {
+          lastVideoSnapshotRef.current = now;
+          setVideoSnapshot({ smile, browRaise, eyeOpenness, headMovement, engagement });
+        }
+      }
+    } catch (err) {
+      console.error("Video processing error", err);
+    }
+
+    videoRafRef.current = requestAnimationFrame(() => {
+      processVideo().catch(() => undefined);
+    });
+  }, []);
+
+  const initializeDetector = useCallback(async () => {
+    if (detectorRef.current) {
+      return detectorRef.current;
+    }
+
+    const [faceModule, faceMeshModule] = await Promise.all([
+      import("@tensorflow-models/face-landmarks-detection") as Promise<FaceLandmarksModule>,
+      import("@mediapipe/face_mesh") as Promise<MediapipeModule>
+    ]);
+
+    const version = faceMeshModule.VERSION ?? "0.4.1633559617";
+    const detector = await faceModule.createDetector(faceModule.SupportedModels.MediaPipeFaceMesh, {
+      runtime: "mediapipe",
+      refineLandmarks: true,
+      solutionPath: `https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@${version}`
+    });
+
+    detectorRef.current = detector;
+    return detector;
+  }, []);
+
+  const sendAnalysis = useCallback(async () => {
+    if (!isRunningRef.current) {
+      return;
+    }
+
+    const now = Date.now();
+    const voiceFeatures = voiceFeaturesRef.current;
+    const videoFeatures = videoFeaturesRef.current;
+
+    const payload: Record<string, unknown> = {
+      text: textRef.current.trim() ? textRef.current.trim() : null,
+      metadata: { window_ms: 3000, generated_at: new Date(now).toISOString() }
+    };
+
+    if (now - voiceFeatures.updatedAt < 1500) {
+      payload.voice = {
+        energy: voiceFeatures.energy,
+        pitch: voiceFeatures.pitch,
+        tempo: voiceFeatures.tempo,
+        jitter: voiceFeatures.jitter,
+        confidence: voiceFeatures.confidence
+      };
+    }
+
+    if (now - videoFeatures.updatedAt < 1500) {
+      payload.video = {
+        smile: videoFeatures.smile,
+        brow_raise: videoFeatures.browRaise,
+        eye_openness: videoFeatures.eyeOpenness,
+        head_movement: videoFeatures.headMovement,
+        engagement: videoFeatures.engagement
+      };
+    }
+
+    if (!payload.text && !payload.voice && !payload.video) {
+      return;
+    }
+
+    try {
+      const response = await fetch(`${API_BASE}/emotion/analyze`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+
+      if (!response.ok) {
+        throw new Error(`Request failed with ${response.status}`);
+      }
+
+      const data = (await response.json()) as EmotionAnalysisResponse;
+      setAnalysis(data);
+      setStatus(
+        `Dominant emotion: ${capitalize(data.dominant_emotion)} (${formatPercent(data.confidence)})`
+      );
+      setError(null);
+    } catch (err) {
+      console.error("Emotion analysis request failed", err);
+      setError("Unable to reach the backend emotion service.");
+    }
+  }, []);
+
+  const startSession = useCallback(async () => {
+    if (isRunningRef.current) {
+      return;
+    }
+
+    try {
+      setStatus("Requesting camera and microphone access…");
+      setError(null);
+
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: { facingMode: "user" } });
+      mediaStreamRef.current = stream;
+
+      const video = videoRef.current;
+      if (video) {
+        video.srcObject = stream;
+        await video.play();
+      }
+
+      const audioContext = new AudioContext();
+      const analyser = audioContext.createAnalyser();
+      analyser.fftSize = 2048;
+      analyser.smoothingTimeConstant = 0.6;
+      const source = audioContext.createMediaStreamSource(stream);
+      source.connect(analyser);
+      audioContextRef.current = audioContext;
+      analyserRef.current = analyser;
+
+      voiceFeaturesRef.current = {
+        energy: 0,
+        pitch: 0,
+        tempo: 0,
+        jitter: 0,
+        confidence: 0,
+        lastPitch: 0,
+        updatedAt: Date.now()
+      };
+
+      videoFeaturesRef.current = {
+        smile: 0,
+        browRaise: 0,
+        eyeOpenness: 0,
+        headMovement: 0,
+        engagement: 0,
+        updatedAt: Date.now(),
+        lastNoseX: 0,
+        lastNoseY: 0
+      };
+
+      await initializeDetector();
+
+      setIsRunning(true);
+      isRunningRef.current = true;
+      setStatus("Collecting real-time signals…");
+      processAudio();
+      processVideo().catch(() => undefined);
+
+      pollIntervalRef.current = window.setInterval(() => {
+        sendAnalysis().catch(() => undefined);
+      }, 3000);
+
+      await sendAnalysis();
+    } catch (err) {
+      console.error("Unable to start session", err);
+      setStatus("Unable to access required devices. Please ensure permissions are granted.");
+      setError("Camera or microphone access was denied.");
+      await cleanup();
+      setIsRunning(false);
+    }
+  }, [cleanup, initializeDetector, processAudio, processVideo, sendAnalysis]);
+
+  const stopSession = useCallback(async () => {
+    if (!isRunningRef.current) {
+      return;
+    }
+
+    setIsRunning(false);
+    isRunningRef.current = false;
+    setStatus("Session paused. Start again to resume live analysis.");
+    await cleanup();
+  }, [cleanup]);
+
+  const breakdownCards = useMemo(() => {
+    if (!analysis) return null;
+
+    const entries: Array<{ modality: string; scores: EmotionProbabilities | null | undefined }> = [
+      { modality: "text", scores: analysis.modality_breakdown.text },
+      { modality: "voice", scores: analysis.modality_breakdown.voice },
+      { modality: "video", scores: analysis.modality_breakdown.video }
+    ];
+
+    return entries.map(({ modality, scores }) => (
+      <div key={modality} className="space-y-3 rounded-xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900/40">
+        <div className="flex items-center justify-between">
+          <Heading as="h3" size="4" className="capitalize">
+            {modality}
+          </Heading>
+          <Text className="text-sm text-slate-500 dark:text-slate-400">
+            weight {formatPercent(analysis.modality_weights[modality] ?? 0)}
+          </Text>
+        </div>
+        {scores ? (
+          <div className="space-y-2">
+            {EMOTION_ORDER.map((emotion) => (
+              <EmotionBar key={emotion} emotion={emotion} value={scores[emotion] ?? 0} />
+            ))}
+          </div>
+        ) : (
+          <Text className="text-sm text-slate-500 dark:text-slate-400">No signal captured during this window.</Text>
+        )}
+      </div>
+    ));
+  }, [analysis]);
 
   return (
     <Theme appearance="inherit">
-      <main className="mx-auto flex min-h-screen w-full max-w-5xl flex-col gap-16 px-6 py-24">
-        <motion.section
-          variants={heroVariants}
-          initial="hidden"
-          animate="visible"
-          transition={{ duration: 0.5, ease: "easeOut" }}
-          className="space-y-6"
-        >
-          <span className="inline-flex items-center gap-2 rounded-full bg-slate-200 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600 dark:bg-slate-800 dark:text-slate-200">
-            <SunIcon className="h-4 w-4" />
-            Fast foundations
-          </span>
-          <Heading as="h1" size="8" className="font-heading text-balance text-4xl md:text-5xl">
-            Ship modern product experiences with confidence.
+      <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-10 px-6 py-12">
+        <section className="space-y-4">
+          <Heading as="h1" size="8" className="font-heading text-balance text-3xl md:text-4xl">
+            Multi-modal emotion console
           </Heading>
-          <Text as="p" size="4" className="max-w-2xl text-lg text-slate-600 dark:text-slate-300">
-            This monorepo pairs a type-safe Next.js frontend with a FastAPI backend so
-            that teams can iterate quickly without sacrificing best practices. Tailwind
-            CSS, shadcn/ui patterns, and Radix Themes are ready for you to build on.
+          <Text as="p" size="4" className="max-w-3xl text-slate-600 dark:text-slate-300">
+            Capture voice, text, and facial movement in real time to infer emotions using a Plutchik-based taxonomy.
+            Start a session to stream local audio/video features to the FastAPI backend and watch the fused prediction
+            update live.
           </Text>
-          <Flex gap="3" wrap="wrap">
-            <Button onClick={() => setClicks((count) => count + 1)}>Primary action</Button>
-            <Button variant="outline" onClick={() => setClicks(0)}>
-              Reset clicks ({clicks})
+          <div className="flex flex-wrap items-center gap-3">
+            <Button onClick={startSession} disabled={isRunning}>
+              {isRunning ? "Capturing…" : "Start live capture"}
             </Button>
-          </Flex>
-        </motion.section>
-        <section className="grid gap-6 md:grid-cols-2">
-          {features.map((feature) => (
-            <motion.article
-              key={feature.title}
-              className={cn(
-                "rounded-2xl border border-slate-200 bg-white/70 p-6 shadow-sm backdrop-blur dark:border-slate-800 dark:bg-slate-900/50"
-              )}
-              variants={heroVariants}
-              initial="hidden"
-              whileInView="visible"
-              viewport={{ once: true, amount: 0.3 }}
-              transition={{ duration: 0.4, delay: feature.delay }}
-            >
-              <feature.icon className="mb-4 h-8 w-8 text-brand" />
-              <Heading as="h3" size="5" className="mb-2 font-heading">
-                {feature.title}
-              </Heading>
-              <Text as="p" size="3" className="text-slate-600 dark:text-slate-300">
-                {feature.description}
-              </Text>
-            </motion.article>
-          ))}
+            <Button variant="outline" onClick={stopSession} disabled={!isRunning}>
+              Stop session
+            </Button>
+            <Text className="text-sm text-slate-500 dark:text-slate-400">{status}</Text>
+          </div>
+          {error ? <Text className="text-sm text-rose-500">{error}</Text> : null}
         </section>
+
+        <section className="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+          <div className="space-y-6">
+            <div className="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900/40">
+              <Heading as="h2" size="4" className="mb-3 font-heading">
+                Live camera feed
+              </Heading>
+              <div className="relative overflow-hidden rounded-xl bg-black">
+                <video ref={videoRef} playsInline muted className="h-64 w-full rounded-xl object-cover" />
+              </div>
+              {videoSnapshot ? (
+                <SignalList
+                  title="Facial features"
+                  signals={{
+                    smile: videoSnapshot.smile,
+                    "brow raise": videoSnapshot.browRaise,
+                    "eye openness": videoSnapshot.eyeOpenness,
+                    "head movement": videoSnapshot.headMovement,
+                    engagement: videoSnapshot.engagement
+                  }}
+                />
+              ) : (
+                <Text className="text-sm text-slate-500 dark:text-slate-400">
+                  Enable the session to capture facial expression metrics.
+                </Text>
+              )}
+            </div>
+
+            <div className="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900/40">
+              <Heading as="h2" size="4" className="mb-3 font-heading">
+                Text transcript
+              </Heading>
+              <textarea
+                value={textInput}
+                onChange={(event) => setTextInput(event.target.value)}
+                className="min-h-[140px] w-full resize-y rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200 dark:border-slate-700 dark:bg-slate-950"
+                placeholder="Type or paste text captured from your conversation…"
+              />
+              <Text className="mt-2 block text-xs text-slate-500 dark:text-slate-400">
+                The full transcript is sent with each inference window to enrich the prediction.
+              </Text>
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <div className="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900/40">
+              <Heading as="h2" size="4" className="mb-3 font-heading">
+                Voice metrics
+              </Heading>
+              {voiceSnapshot ? (
+                <SignalList
+                  title="Acoustic features"
+                  signals={{
+                    energy: voiceSnapshot.energy,
+                    pitch: voiceSnapshot.pitch,
+                    tempo: voiceSnapshot.tempo,
+                    jitter: voiceSnapshot.jitter,
+                    confidence: voiceSnapshot.confidence
+                  }}
+                  formatter={{
+                    pitch: (value) => `${formatNumber(value, 0)} Hz`,
+                    energy: (value) => formatNumber(value, 3),
+                    tempo: (value) => `${formatNumber(value, 2)} wps`,
+                    jitter: (value) => formatNumber(value, 2),
+                    confidence: (value) => formatPercent(value)
+                  }}
+                />
+              ) : (
+                <Text className="text-sm text-slate-500 dark:text-slate-400">
+                  Start capturing to compute RMS energy, pitch, tempo, and jitter.
+                </Text>
+              )}
+            </div>
+
+            {analysis ? (
+              <div className="space-y-5 rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900/40">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Heading as="h2" size="4" className="font-heading capitalize">
+                      {analysis.dominant_emotion}
+                    </Heading>
+                    <Text className="text-sm text-slate-500 dark:text-slate-400">
+                      Confidence {formatPercent(analysis.confidence)}
+                    </Text>
+                  </div>
+                  <span className="rounded-full bg-slate-900/5 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600 dark:bg-slate-100/10 dark:text-slate-200">
+                    Taxonomy · {analysis.taxonomy.replace("_", " ")}
+                  </span>
+                </div>
+
+                <div className="space-y-2">
+                  {EMOTION_ORDER.map((emotion) => (
+                    <EmotionBar key={emotion} emotion={emotion} value={analysis.aggregated[emotion] ?? 0} />
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <div className="rounded-2xl border border-dashed border-slate-300 bg-white/50 p-4 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900/20 dark:text-slate-400">
+                Aggregated predictions will appear here once the backend returns the first inference window.
+              </div>
+            )}
+          </div>
+        </section>
+
+        {analysis ? <section className="grid gap-4 md:grid-cols-3">{breakdownCards}</section> : null}
       </main>
     </Theme>
   );
 }
 
-type Feature = {
+type SignalListProps = {
   title: string;
-  description: string;
-  icon: (props: SVGProps<SVGSVGElement>) => JSX.Element;
-  delay: number;
+  signals: Record<string, number>;
+  formatter?: Partial<Record<string, (value: number) => string>>;
 };
 
-const features: Feature[] = [
-  {
-    title: "Component-driven UI",
-    description:
-      "Tailwind CSS, Radix Themes, and shadcn-style primitives provide a cohesive design system that scales with your product.",
-    icon: (props) => (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" {...props}>
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M12 6v6l3.5 2.1M4 6h16M4 10h4m12 8H4"
-        />
-      </svg>
-    ),
-    delay: 0.1
-  },
-  {
-    title: "API first backend",
-    description:
-      "FastAPI comes configured with modular routers, typed models, and first-class async support for building reliable services.",
-    icon: (props) => (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" {...props}>
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M4 7h16M4 12h8m-8 5h12"
-        />
-      </svg>
-    ),
-    delay: 0.2
-  },
-  {
-    title: "Production-ready DX",
-    description:
-      "Opinionated tooling including ESLint, Prettier, and TypeScript keeps your codebase consistent across contributors.",
-    icon: (props) => (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" {...props}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="m6 9 6 6 6-6" />
-      </svg>
-    ),
-    delay: 0.3
-  },
-  {
-    title: "Animations built-in",
-    description:
-      "Framer Motion is wired up so you can focus on delightful interactions instead of boilerplate integration work.",
-    icon: (props) => (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" {...props}>
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M4 12c1.5-4 4.5-6 8-6s6.5 2 8 6c-1.5 4-4.5 6-8 6s-6.5-2-8-6z"
-        />
-      </svg>
-    ),
-    delay: 0.4
-  }
-];
+function SignalList({ title, signals, formatter }: SignalListProps) {
+  return (
+    <div className="space-y-2">
+      <Heading as="h3" size="3" className="font-heading text-slate-700 dark:text-slate-200">
+        {title}
+      </Heading>
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm text-slate-600 dark:text-slate-300">
+        {Object.entries(signals).map(([key, value]) => (
+          <div key={key} className="flex flex-col">
+            <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">{key}</dt>
+            <dd className="font-medium">
+              {formatter?.[key]?.(value) ?? formatNumber(value, 2)}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+type EmotionBarProps = {
+  emotion: string;
+  value: number;
+};
+
+function EmotionBar({ emotion, value }: EmotionBarProps) {
+  const percent = clamp(value);
+  const colorClass = EMOTION_COLORS[emotion] ?? "bg-slate-400";
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        <span>{emotion}</span>
+        <span>{formatPercent(percent)}</span>
+      </div>
+      <div className="h-2 rounded-full bg-slate-200 dark:bg-slate-800">
+        <div className={`${colorClass} h-2 rounded-full`} style={{ width: `${percent * 100}%` }} />
+      </div>
+    </div>
+  );
+}
+
+const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,8 +12,10 @@
   "dependencies": {
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/themes": "^3.0.4",
+    "@mediapipe/face_mesh": "^0.4.1633559617",
     "@tailwindcss/typography": "^0.5.13",
     "@tanstack/react-query": "^5.45.0",
+    "@tensorflow-models/face-landmarks-detection": "^1.0.4",
     "@types/node": "^20.14.2",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",


### PR DESCRIPTION
## Summary
- implement a Plutchik-based emotion analyzer service with text, voice, and video heuristics plus a new FastAPI endpoint
- replace the landing page with a live multimodal emotion console that streams audio/video features to the backend
- document taxonomy and architecture decisions for the emotion pipeline

## Testing
- pytest *(fails: missing fastapi dependency in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d808a86d988332a1b7f5f246b06447