### PR TITLE
Replace TensorFlow face detector with MediaPipe Tasks

### DIFF
--- a/agent-decisions/mediapipe-migration.md
+++ b/agent-decisions/mediapipe-migration.md
@@ -1,0 +1,18 @@
+# MediaPipe Face Landmarker Migration
+
+## Context
+- The frontend previously imported `@tensorflow-models/face-landmarks-detection`, which in turn requires `@tensorflow/tfjs-core`. The dependency chain caused the build failure shown in the provided screenshot because the TensorFlow JS core package was not installed during the Next.js compilation.
+- The user requested a solution that does not rely on TensorFlow-based models and asked for a better alternative model after researching options.
+
+## Decision
+- Switched the facial landmark detection stack to the MediaPipe Tasks Face Landmarker (`@mediapipe/tasks-vision`). The task API wraps the same high-quality face mesh model but ships as a pure WebAssembly bundle, removing the TensorFlow runtime dependency entirely.
+- Pinned the WASM bundle (`@mediapipe/tasks-vision@0.10.4`) and referenced the official hosted `.task` model from Google Storage to ensure deterministic loading in production builds.
+- Reworked the video-processing loop to consume normalized landmarks from the new API and convert them into pixel coordinates before calculating smile, brow raise, and other custom metrics.
+
+## Rationale
+- MediaPipe Tasks is the recommended successor to the legacy TensorFlow.js integration, according to the Google AI/MediaPipe documentation, and it avoids the large TensorFlow payload. It is also optimized for real-time, on-device inference in browsers.
+- By pinning explicit CDN URLs for the WASM runtime and model asset, the application can download the artifacts without bundling them, keeping the Next.js build lightweight.
+- Updating the measurement logic to use normalized landmarks keeps the existing UI logic intact while ensuring numerical stability (e.g., treating the very first frame’s head movement as zero to avoid spikes).
+
+## Follow-up
+- The development container cannot currently download the npm package (`@mediapipe/tasks-vision`) because of a 403 from the npm registry. Once network access is restored, run `npm install` in `frontend/` to materialize the dependency in `node_modules` before building locally.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,10 +12,9 @@
   "dependencies": {
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/themes": "^3.0.4",
-    "@mediapipe/face_mesh": "^0.4.1633559617",
+    "@mediapipe/tasks-vision": "^0.10.4",
     "@tailwindcss/typography": "^0.5.13",
     "@tanstack/react-query": "^5.45.0",
-    "@tensorflow-models/face-landmarks-detection": "^1.0.4",
     "@types/node": "^20.14.2",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",


### PR DESCRIPTION
## Summary
- replace the TensorFlow.js face landmarks dependency with the MediaPipe Tasks face landmarker and pin its WASM/model URLs
- convert the video landmark processing loop to consume normalized coordinates from MediaPipe and smooth the first-frame head movement calculation
- document the model migration and rationale in `agent-decisions/`

## Testing
- npm install *(fails: npm cannot download @mediapipe/tasks-vision due to 403 from the registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d80e4f9ab883328fa549f0c2e47791