### PR TITLE
Ensure realtime conversation uploads context frame before connecting

### DIFF
--- a/agent-decisions/realtime-conversation-screenshots.md
+++ b/agent-decisions/realtime-conversation-screenshots.md
@@ -1,0 +1,17 @@
+# Realtime conversation screenshot capture
+
+## Context
+- Feature: realtime conversation panel (`frontend/components/realtime-conversation.tsx`).
+- Goal: ensure a fresh vision frame is uploaded to the backend when the user starts a conversation so the backend has up-to-date context.
+
+## Decision
+- Updated the `startConversation` flow to `await` the optional `onShareVisionFrame` callback.
+- Wrapped the awaited call in `try/catch` to surface non-blocking console warnings instead of uncaught promise rejections.
+
+## Rationale
+- Awaiting the callback guarantees the screenshot upload request is dispatched before negotiating the realtime session.
+- Preserves existing error handling semantics while avoiding unhandled promise rejections and making the intent explicit.
+
+## Alternatives considered
+- Leaving the fire-and-forget invocation. Rejected because the backend might complete session negotiation before the upload finishes, leading to missing context.
+- Forcing screenshot capture regardless of capture session state. Not pursued to avoid race conditions when the capture session is inactive.

--- a/frontend/components/realtime-conversation.tsx
+++ b/frontend/components/realtime-conversation.tsx
@@ -208,9 +208,11 @@ export function RealtimeConversationPanel({
 
     try {
       if (onShareVisionFrame) {
-        onShareVisionFrame().catch((err) => {
+        try {
+          await onShareVisionFrame();
+        } catch (err) {
           console.warn("Unable to capture context frame", err);
-        });
+        }
       }
 
       const response = await fetch(`${API_BASE}/realtime/session`, {


### PR DESCRIPTION
## Summary
- await the optional onShareVisionFrame callback when starting a realtime session so the context image upload is dispatched before negotiation
- add design notes covering the decision to block on screenshot capture and error handling adjustments

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8211ad6488332a136490ce67e0173