### PR TITLE
Add Auth0 login and Stripe checkout integrations

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,3 +9,16 @@
 
 # Environment label used for logging and observability. Examples: development, staging, production.
 # ENVIRONMENT=development
+
+# Auth0 configuration for authentication flows.
+# AUTH0_DOMAIN=your-tenant.us.auth0.com
+# AUTH0_CLIENT_ID=
+# AUTH0_CLIENT_SECRET=
+# AUTH0_AUDIENCE=
+# AUTH0_DEFAULT_REDIRECT_URI=http://localhost:3000/api/auth/callback
+
+# Stripe configuration for hosted checkout sessions.
+# STRIPE_API_KEY=
+# STRIPE_DEFAULT_PRICE_ID=
+# STRIPE_SUCCESS_URL=http://localhost:3000/payments/success
+# STRIPE_CANCEL_URL=http://localhost:3000/payments/cancel

--- a/backend/README.md
+++ b/backend/README.md
@@ -44,6 +44,15 @@ Available settings (with defaults shown in `app/core/config.py`):
 - `OPENAI_REALTIME_MODEL` — Realtime model identifier (`gpt-4o-realtime-preview-2024-12-17`).
 - `OPENAI_REALTIME_VOICE` — Voice used for speech output (`verse`).
 - `OPENAI_REALTIME_INSTRUCTIONS` — Optional system prompt for each session.
+- `AUTH0_DOMAIN` — Auth0 tenant domain used for hosted login (no default).
+- `AUTH0_CLIENT_ID` — Client ID for the Auth0 application (no default).
+- `AUTH0_CLIENT_SECRET` — Client secret for the Auth0 application (no default).
+- `AUTH0_AUDIENCE` — Optional API audience to request during login.
+- `AUTH0_DEFAULT_REDIRECT_URI` — Default redirect URI passed to Auth0 when one is not supplied by the client.
+- `STRIPE_API_KEY` — Secret key for Stripe API access (no default).
+- `STRIPE_DEFAULT_PRICE_ID` — Optional default Price ID used for checkout sessions.
+- `STRIPE_SUCCESS_URL` — Default success redirect for Stripe Checkout sessions.
+- `STRIPE_CANCEL_URL` — Default cancel redirect for Stripe Checkout sessions.
 
 If a key is omitted it will fall back to the default defined in `Settings`.
 
@@ -97,9 +106,16 @@ backend/
 │   ├── models/
 │   │   └── __init__.py
 │   ├── schemas/
-│   │   └── health.py
+│   │   ├── auth.py
+│   │   ├── emotion.py
+│   │   ├── health.py
+│   │   ├── payments.py
+│   │   └── realtime.py
 │   ├── services/
-│   │   └── __init__.py
+│   │   ├── __init__.py
+│   │   ├── auth.py
+│   │   ├── emotion.py
+│   │   └── payments.py
 │   └── main.py
 ├── tests/
 │   └── test_health.py

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,0 +1,81 @@
+"""Authentication-related API routes."""
+
+from fastapi import APIRouter, Depends, Header, HTTPException
+
+from app.api.dependencies import get_auth_client
+from app.schemas.auth import (
+    AuthLoginRequest,
+    AuthLoginResponse,
+    AuthTokenExchangeRequest,
+    AuthTokenResponse,
+    AuthUserInfo,
+)
+from app.services.auth import Auth0Client, Auth0Error
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/login", response_model=AuthLoginResponse)
+async def start_login(
+    payload: AuthLoginRequest,
+    auth_client: Auth0Client = Depends(get_auth_client),
+) -> AuthLoginResponse:
+    """Generate an Auth0 authorization URL for the hosted login page."""
+
+    try:
+        url = auth_client.build_authorization_url(
+            redirect_uri=payload.redirect_uri,
+            state=payload.state,
+            prompt=payload.prompt,
+            screen_hint=payload.screen_hint,
+            scope=payload.scope,
+        )
+    except Auth0Error as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return AuthLoginResponse(authorization_url=url)
+
+
+@router.post("/callback", response_model=AuthTokenResponse)
+async def complete_login(
+    payload: AuthTokenExchangeRequest,
+    auth_client: Auth0Client = Depends(get_auth_client),
+) -> AuthTokenResponse:
+    """Exchange an Auth0 authorization code for tokens."""
+
+    try:
+        tokens = await auth_client.exchange_code_for_tokens(
+            code=payload.code,
+            redirect_uri=payload.redirect_uri,
+            code_verifier=payload.code_verifier,
+        )
+    except Auth0Error as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return AuthTokenResponse(
+        access_token=tokens.access_token,
+        token_type=tokens.token_type,
+        expires_in=tokens.expires_in,
+        refresh_token=tokens.refresh_token,
+        id_token=tokens.id_token,
+        scope=tokens.scope,
+    )
+
+
+@router.get("/userinfo", response_model=AuthUserInfo)
+async def fetch_user_info(
+    authorization: str = Header(..., alias="Authorization"),
+    auth_client: Auth0Client = Depends(get_auth_client),
+) -> AuthUserInfo:
+    """Fetch the Auth0 user profile for the provided access token."""
+
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        raise HTTPException(status_code=401, detail="Bearer access token required")
+
+    try:
+        payload = await auth_client.get_user_info(token)
+    except Auth0Error as exc:
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
+
+    return AuthUserInfo.model_validate(payload)

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -3,7 +3,9 @@ from functools import lru_cache
 from fastapi import HTTPException
 
 from app.core.config import Settings, get_settings as _get_settings
+from app.services.auth import Auth0Client, Auth0ConfigurationError
 from app.services.emotion import EmotionAnalyzer
+from app.services.payments import StripePaymentProcessor, StripeConfigurationError
 from app.services.realtime import RealtimeSessionClient
 
 
@@ -40,3 +42,50 @@ def get_realtime_client() -> RealtimeSessionClient:
         voice=settings.openai_realtime_voice,
         instructions=settings.openai_realtime_instructions,
     )
+
+
+@lru_cache
+def _get_auth_client() -> Auth0Client:
+    settings = _get_settings()
+    try:
+        return Auth0Client(
+            domain=settings.auth0_domain or "",
+            client_id=settings.auth0_client_id or "",
+            client_secret=settings.auth0_client_secret or "",
+            audience=settings.auth0_audience,
+            default_redirect_uri=settings.auth0_default_redirect_uri,
+        )
+    except Auth0ConfigurationError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+def get_auth_client() -> Auth0Client:
+    """Return a configured Auth0 client or raise if misconfigured."""
+
+    client = _get_auth_client()
+    if not client:
+        raise HTTPException(status_code=503, detail="Authentication service unavailable")
+    return client
+
+
+@lru_cache
+def _get_payment_processor() -> StripePaymentProcessor:
+    settings = _get_settings()
+    try:
+        return StripePaymentProcessor(
+            api_key=settings.stripe_api_key or "",
+            default_price_id=settings.stripe_default_price_id,
+            default_success_url=settings.stripe_success_url,
+            default_cancel_url=settings.stripe_cancel_url,
+        )
+    except StripeConfigurationError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+def get_payment_processor() -> StripePaymentProcessor:
+    """Return a configured Stripe payment processor or raise if misconfigured."""
+
+    processor = _get_payment_processor()
+    if not processor:
+        raise HTTPException(status_code=503, detail="Payment service unavailable")
+    return processor

--- a/backend/app/api/payments.py
+++ b/backend/app/api/payments.py
@@ -1,0 +1,34 @@
+"""Payment-related API routes."""
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.api.dependencies import get_payment_processor
+from app.schemas.payments import CheckoutSessionRequest, CheckoutSessionResponse
+from app.services.payments import StripePaymentError, StripePaymentProcessor
+
+router = APIRouter(prefix="/payments", tags=["payments"])
+
+
+@router.post("/checkout", response_model=CheckoutSessionResponse)
+async def create_checkout_session(
+    payload: CheckoutSessionRequest,
+    processor: StripePaymentProcessor = Depends(get_payment_processor),
+) -> CheckoutSessionResponse:
+    """Create a Stripe Checkout session and return the redirect URL."""
+
+    try:
+        session = await processor.create_checkout_session(
+            price_id=payload.price_id,
+            quantity=payload.quantity,
+            success_url=payload.success_url,
+            cancel_url=payload.cancel_url,
+            customer_email=payload.customer_email,
+            mode=payload.mode,
+        )
+    except StripePaymentError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return CheckoutSessionResponse(
+        session_id=session.session_id,
+        checkout_url=session.url,
+    )

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -2,34 +2,20 @@ import base64
 import binascii
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
-from app.api.dependencies import (
-    get_auth_client,
-    get_emotion_analyzer,
-    get_payment_processor,
-    get_realtime_client,
-    get_settings,
-)
+from app.api import auth as auth_routes
+from app.api import payments as payment_routes
+from app.api.dependencies import get_emotion_analyzer, get_realtime_client, get_settings
 from app.core.config import Settings
-from app.schemas.auth import (
-    AuthLoginRequest,
-    AuthLoginResponse,
-    AuthTokenExchangeRequest,
-    AuthTokenResponse,
-    AuthUserInfo,
-)
 from app.schemas.emotion import EmotionAnalysisRequest, EmotionAnalysisResponse
 from app.schemas.health import HealthResponse
-from app.schemas.payments import CheckoutSessionRequest, CheckoutSessionResponse
 from app.schemas.realtime import (
     RealtimeSessionToken,
     VisionFrameRequest,
     VisionFrameResponse,
 )
-from app.services.auth import Auth0Client, Auth0Error
 from app.services.emotion import EmotionAnalyzer
-from app.services.payments import StripePaymentError, StripePaymentProcessor
 from app.services.realtime import RealtimeSessionClient, RealtimeSessionError
 
 router = APIRouter()
@@ -54,72 +40,6 @@ async def analyze_emotion(
     """Analyze multi-modal signals and return an emotion profile."""
 
     return analyzer.analyze(payload)
-
-
-@router.post("/auth/login", response_model=AuthLoginResponse, tags=["auth"])
-async def start_login(
-    payload: AuthLoginRequest,
-    auth_client: Auth0Client = Depends(get_auth_client),
-) -> AuthLoginResponse:
-    """Generate an Auth0 authorization URL for the hosted login page."""
-
-    try:
-        url = auth_client.build_authorization_url(
-            redirect_uri=payload.redirect_uri,
-            state=payload.state,
-            prompt=payload.prompt,
-            screen_hint=payload.screen_hint,
-            scope=payload.scope,
-        )
-    except Auth0Error as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-    return AuthLoginResponse(authorization_url=url)
-
-
-@router.post("/auth/callback", response_model=AuthTokenResponse, tags=["auth"])
-async def complete_login(
-    payload: AuthTokenExchangeRequest,
-    auth_client: Auth0Client = Depends(get_auth_client),
-) -> AuthTokenResponse:
-    """Exchange an Auth0 authorization code for tokens."""
-
-    try:
-        tokens = await auth_client.exchange_code_for_tokens(
-            code=payload.code,
-            redirect_uri=payload.redirect_uri,
-            code_verifier=payload.code_verifier,
-        )
-    except Auth0Error as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-    return AuthTokenResponse(
-        access_token=tokens.access_token,
-        token_type=tokens.token_type,
-        expires_in=tokens.expires_in,
-        refresh_token=tokens.refresh_token,
-        id_token=tokens.id_token,
-        scope=tokens.scope,
-    )
-
-
-@router.get("/auth/userinfo", response_model=AuthUserInfo, tags=["auth"])
-async def fetch_user_info(
-    authorization: str = Header(..., alias="Authorization"),
-    auth_client: Auth0Client = Depends(get_auth_client),
-) -> AuthUserInfo:
-    """Fetch the Auth0 user profile for the provided access token."""
-
-    scheme, _, token = authorization.partition(" ")
-    if scheme.lower() != "bearer" or not token:
-        raise HTTPException(status_code=401, detail="Bearer access token required")
-
-    try:
-        payload = await auth_client.get_user_info(token)
-    except Auth0Error as exc:
-        raise HTTPException(status_code=401, detail=str(exc)) from exc
-
-    return AuthUserInfo.model_validate(payload)
 
 
 @router.post("/realtime/session", response_model=RealtimeSessionToken, tags=["realtime"])
@@ -161,31 +81,5 @@ async def accept_vision_frame(payload: VisionFrameRequest) -> VisionFrameRespons
         received_at=received_at,
     )
 
-
-@router.post(
-    "/payments/checkout",
-    response_model=CheckoutSessionResponse,
-    tags=["payments"],
-)
-async def create_checkout_session(
-    payload: CheckoutSessionRequest,
-    processor: StripePaymentProcessor = Depends(get_payment_processor),
-) -> CheckoutSessionResponse:
-    """Create a Stripe Checkout session and return the redirect URL."""
-
-    try:
-        session = await processor.create_checkout_session(
-            price_id=payload.price_id,
-            quantity=payload.quantity,
-            success_url=payload.success_url,
-            cancel_url=payload.cancel_url,
-            customer_email=payload.customer_email,
-            mode=payload.mode,
-        )
-    except StripePaymentError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-    return CheckoutSessionResponse(
-        session_id=session.session_id,
-        checkout_url=session.url,
-    )
+router.include_router(auth_routes.router)
+router.include_router(payment_routes.router)

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -2,18 +2,34 @@ import base64
 import binascii
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException
 
-from app.api.dependencies import get_emotion_analyzer, get_realtime_client, get_settings
+from app.api.dependencies import (
+    get_auth_client,
+    get_emotion_analyzer,
+    get_payment_processor,
+    get_realtime_client,
+    get_settings,
+)
 from app.core.config import Settings
+from app.schemas.auth import (
+    AuthLoginRequest,
+    AuthLoginResponse,
+    AuthTokenExchangeRequest,
+    AuthTokenResponse,
+    AuthUserInfo,
+)
 from app.schemas.emotion import EmotionAnalysisRequest, EmotionAnalysisResponse
 from app.schemas.health import HealthResponse
+from app.schemas.payments import CheckoutSessionRequest, CheckoutSessionResponse
 from app.schemas.realtime import (
     RealtimeSessionToken,
     VisionFrameRequest,
     VisionFrameResponse,
 )
+from app.services.auth import Auth0Client, Auth0Error
 from app.services.emotion import EmotionAnalyzer
+from app.services.payments import StripePaymentError, StripePaymentProcessor
 from app.services.realtime import RealtimeSessionClient, RealtimeSessionError
 
 router = APIRouter()
@@ -38,6 +54,72 @@ async def analyze_emotion(
     """Analyze multi-modal signals and return an emotion profile."""
 
     return analyzer.analyze(payload)
+
+
+@router.post("/auth/login", response_model=AuthLoginResponse, tags=["auth"])
+async def start_login(
+    payload: AuthLoginRequest,
+    auth_client: Auth0Client = Depends(get_auth_client),
+) -> AuthLoginResponse:
+    """Generate an Auth0 authorization URL for the hosted login page."""
+
+    try:
+        url = auth_client.build_authorization_url(
+            redirect_uri=payload.redirect_uri,
+            state=payload.state,
+            prompt=payload.prompt,
+            screen_hint=payload.screen_hint,
+            scope=payload.scope,
+        )
+    except Auth0Error as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return AuthLoginResponse(authorization_url=url)
+
+
+@router.post("/auth/callback", response_model=AuthTokenResponse, tags=["auth"])
+async def complete_login(
+    payload: AuthTokenExchangeRequest,
+    auth_client: Auth0Client = Depends(get_auth_client),
+) -> AuthTokenResponse:
+    """Exchange an Auth0 authorization code for tokens."""
+
+    try:
+        tokens = await auth_client.exchange_code_for_tokens(
+            code=payload.code,
+            redirect_uri=payload.redirect_uri,
+            code_verifier=payload.code_verifier,
+        )
+    except Auth0Error as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return AuthTokenResponse(
+        access_token=tokens.access_token,
+        token_type=tokens.token_type,
+        expires_in=tokens.expires_in,
+        refresh_token=tokens.refresh_token,
+        id_token=tokens.id_token,
+        scope=tokens.scope,
+    )
+
+
+@router.get("/auth/userinfo", response_model=AuthUserInfo, tags=["auth"])
+async def fetch_user_info(
+    authorization: str = Header(..., alias="Authorization"),
+    auth_client: Auth0Client = Depends(get_auth_client),
+) -> AuthUserInfo:
+    """Fetch the Auth0 user profile for the provided access token."""
+
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        raise HTTPException(status_code=401, detail="Bearer access token required")
+
+    try:
+        payload = await auth_client.get_user_info(token)
+    except Auth0Error as exc:
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
+
+    return AuthUserInfo.model_validate(payload)
 
 
 @router.post("/realtime/session", response_model=RealtimeSessionToken, tags=["realtime"])
@@ -77,4 +159,33 @@ async def accept_vision_frame(payload: VisionFrameRequest) -> VisionFrameRespons
         bytes=len(decoded),
         captured_at=payload.captured_at,
         received_at=received_at,
+    )
+
+
+@router.post(
+    "/payments/checkout",
+    response_model=CheckoutSessionResponse,
+    tags=["payments"],
+)
+async def create_checkout_session(
+    payload: CheckoutSessionRequest,
+    processor: StripePaymentProcessor = Depends(get_payment_processor),
+) -> CheckoutSessionResponse:
+    """Create a Stripe Checkout session and return the redirect URL."""
+
+    try:
+        session = await processor.create_checkout_session(
+            price_id=payload.price_id,
+            quantity=payload.quantity,
+            success_url=payload.success_url,
+            cancel_url=payload.cancel_url,
+            customer_email=payload.customer_email,
+            mode=payload.mode,
+        )
+    except StripePaymentError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return CheckoutSessionResponse(
+        session_id=session.session_id,
+        checkout_url=session.url,
     )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -21,6 +21,25 @@ class Settings(BaseSettings):
         default=None, alias="OPENAI_REALTIME_INSTRUCTIONS"
     )
 
+    # Auth0 configuration
+    auth0_domain: str | None = Field(default=None, alias="AUTH0_DOMAIN")
+    auth0_client_id: str | None = Field(default=None, alias="AUTH0_CLIENT_ID")
+    auth0_client_secret: str | None = Field(
+        default=None, alias="AUTH0_CLIENT_SECRET"
+    )
+    auth0_audience: str | None = Field(default=None, alias="AUTH0_AUDIENCE")
+    auth0_default_redirect_uri: str | None = Field(
+        default=None, alias="AUTH0_DEFAULT_REDIRECT_URI"
+    )
+
+    # Stripe configuration
+    stripe_api_key: str | None = Field(default=None, alias="STRIPE_API_KEY")
+    stripe_default_price_id: str | None = Field(
+        default=None, alias="STRIPE_DEFAULT_PRICE_ID"
+    )
+    stripe_success_url: str | None = Field(default=None, alias="STRIPE_SUCCESS_URL")
+    stripe_cancel_url: str | None = Field(default=None, alias="STRIPE_CANCEL_URL")
+
     model_config = {
         "env_file": ".env",
         "case_sensitive": False,

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,0 +1,80 @@
+"""Pydantic models for authentication workflows."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field
+
+
+class AuthLoginRequest(BaseModel):
+    """Payload used to construct an Auth0 authorization URL."""
+
+    redirect_uri: AnyHttpUrl | None = Field(
+        default=None,
+        description="Override the default redirect URI configured for Auth0.",
+    )
+    state: str | None = Field(
+        default=None,
+        description="Opaque value to maintain state between requests.",
+    )
+    prompt: str | None = Field(
+        default=None,
+        description="Pass-through prompt parameter for Auth0 (e.g. 'login').",
+    )
+    screen_hint: str | None = Field(
+        default=None,
+        description="Screen hint to direct Auth0 to a specific UI (e.g. 'signup').",
+    )
+    scope: str | None = Field(
+        default=None,
+        description="Custom OAuth scope to request in addition to the defaults.",
+    )
+
+
+class AuthLoginResponse(BaseModel):
+    """Response containing the fully-qualified authorization URL."""
+
+    authorization_url: AnyHttpUrl
+
+
+class AuthTokenExchangeRequest(BaseModel):
+    """Payload representing the callback from Auth0 after login."""
+
+    code: str = Field(..., description="Authorization code returned by Auth0.")
+    redirect_uri: AnyHttpUrl | None = Field(
+        default=None,
+        description="Redirect URI used during the authorization request.",
+    )
+    code_verifier: str | None = Field(
+        default=None,
+        description="PKCE code verifier when using the Authorization Code Flow with PKCE.",
+    )
+
+
+class AuthTokenResponse(BaseModel):
+    """Subset of Auth0 token response fields returned to the caller."""
+
+    access_token: str
+    token_type: str
+    expires_in: int | None = None
+    refresh_token: str | None = None
+    id_token: str | None = None
+    scope: str | None = None
+
+
+class AuthUserInfo(BaseModel):
+    """User profile returned by Auth0's /userinfo endpoint."""
+
+    model_config = ConfigDict(extra="allow")
+
+    sub: str
+    email: str | None = None
+    name: str | None = None
+    picture: AnyHttpUrl | None = None
+    given_name: str | None = None
+    family_name: str | None = None
+    nickname: str | None = None
+    locale: str | None = None
+    updated_at: str | None = None
+    custom_claims: dict[str, Any] | None = Field(default=None, exclude=True)

--- a/backend/app/schemas/payments.py
+++ b/backend/app/schemas/payments.py
@@ -1,0 +1,41 @@
+"""Pydantic models for payments workflows."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import AnyHttpUrl, BaseModel, EmailStr, Field
+
+
+class CheckoutSessionRequest(BaseModel):
+    """Request payload for initiating a Stripe Checkout session."""
+
+    price_id: str | None = Field(
+        default=None,
+        description="Override the default Stripe Price ID configured in settings.",
+    )
+    quantity: int = Field(default=1, ge=1, description="Quantity of the selected price.")
+    success_url: AnyHttpUrl | None = Field(
+        default=None,
+        description="URL to redirect to when checkout completes successfully.",
+    )
+    cancel_url: AnyHttpUrl | None = Field(
+        default=None,
+        description="URL to redirect to when the user cancels checkout.",
+    )
+    customer_email: EmailStr | None = Field(
+        default=None,
+        description="Optional email to prefill the Stripe checkout form.",
+    )
+    mode: Literal["payment", "subscription"] | None = Field(
+        default=None, description="Checkout mode to use for the session."
+    )
+
+
+class CheckoutSessionResponse(BaseModel):
+    """Response containing the identifier and URL for the hosted checkout."""
+
+    session_id: str = Field(description="Unique identifier of the Stripe Checkout session.")
+    checkout_url: AnyHttpUrl = Field(
+        description="URL that the client should redirect the customer to."
+    )

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,5 +1,22 @@
 """Service layer exports."""
 
+from .auth import Auth0Client, Auth0Error, Auth0Tokens
 from .emotion import EmotionAnalyzer, EmotionTaxonomy
+from .payments import (
+    CheckoutSession,
+    StripeConfigurationError,
+    StripePaymentError,
+    StripePaymentProcessor,
+)
 
-__all__ = ["EmotionAnalyzer", "EmotionTaxonomy"]
+__all__ = [
+    "Auth0Client",
+    "Auth0Error",
+    "Auth0Tokens",
+    "EmotionAnalyzer",
+    "EmotionTaxonomy",
+    "CheckoutSession",
+    "StripeConfigurationError",
+    "StripePaymentError",
+    "StripePaymentProcessor",
+]

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -1,0 +1,168 @@
+"""Authentication service integrations."""
+
+from __future__ import annotations
+
+import urllib.parse
+from dataclasses import dataclass
+
+import httpx
+
+
+class Auth0Error(Exception):
+    """Base exception for Auth0-related failures."""
+
+
+class Auth0ConfigurationError(Auth0Error):
+    """Raised when the Auth0 client is missing required configuration."""
+
+
+@dataclass
+class Auth0Tokens:
+    """Structured representation of tokens returned by Auth0."""
+
+    access_token: str
+    token_type: str
+    expires_in: int | None = None
+    refresh_token: str | None = None
+    id_token: str | None = None
+    scope: str | None = None
+
+
+class Auth0Client:
+    """Lightweight wrapper around Auth0's OAuth endpoints."""
+
+    def __init__(
+        self,
+        *,
+        domain: str,
+        client_id: str,
+        client_secret: str,
+        audience: str | None = None,
+        default_redirect_uri: str | None = None,
+        default_scope: str = "openid profile email offline_access",
+    ) -> None:
+        if not domain or not client_id or not client_secret:
+            raise Auth0ConfigurationError(
+                "Auth0 domain, client ID, and client secret must be provided"
+            )
+
+        self._domain = domain.rstrip("/")
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._audience = audience
+        self._default_redirect_uri = default_redirect_uri
+        self._default_scope = default_scope
+
+    @property
+    def base_url(self) -> str:
+        return f"https://{self._domain}" if not self._domain.startswith("http") else self._domain
+
+    def build_authorization_url(
+        self,
+        *,
+        redirect_uri: str | None = None,
+        state: str | None = None,
+        prompt: str | None = None,
+        screen_hint: str | None = None,
+        scope: str | None = None,
+    ) -> str:
+        """Return the hosted login page URL with the provided parameters."""
+
+        resolved_redirect = redirect_uri or self._default_redirect_uri
+        if not resolved_redirect:
+            raise Auth0ConfigurationError(
+                "A redirect URI must be provided either in the request or settings"
+            )
+
+        query: dict[str, str] = {
+            "response_type": "code",
+            "client_id": self._client_id,
+            "redirect_uri": resolved_redirect,
+            "scope": scope or self._default_scope,
+        }
+
+        if self._audience:
+            query["audience"] = self._audience
+        if state:
+            query["state"] = state
+        if prompt:
+            query["prompt"] = prompt
+        if screen_hint:
+            query["screen_hint"] = screen_hint
+
+        encoded = urllib.parse.urlencode(query)
+        return f"{self.base_url}/authorize?{encoded}"
+
+    async def exchange_code_for_tokens(
+        self,
+        *,
+        code: str,
+        redirect_uri: str | None = None,
+        code_verifier: str | None = None,
+    ) -> Auth0Tokens:
+        """Exchange an authorization code for tokens."""
+
+        if not code:
+            raise Auth0Error("Authorization code is required")
+
+        resolved_redirect = redirect_uri or self._default_redirect_uri
+        if not resolved_redirect:
+            raise Auth0ConfigurationError(
+                "A redirect URI must be provided either in the request or settings"
+            )
+
+        payload = {
+            "grant_type": "authorization_code",
+            "client_id": self._client_id,
+            "client_secret": self._client_secret,
+            "code": code,
+            "redirect_uri": resolved_redirect,
+        }
+
+        if self._audience:
+            payload["audience"] = self._audience
+        if code_verifier:
+            payload["code_verifier"] = code_verifier
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self.base_url}/oauth/token",
+                data=payload,
+                timeout=httpx.Timeout(10.0),
+            )
+
+        if response.status_code >= 400:
+            raise Auth0Error(
+                f"Auth0 token exchange failed ({response.status_code}): {response.text}"
+            )
+
+        data = response.json()
+        return Auth0Tokens(
+            access_token=data.get("access_token"),
+            token_type=data.get("token_type", "Bearer"),
+            expires_in=data.get("expires_in"),
+            refresh_token=data.get("refresh_token"),
+            id_token=data.get("id_token"),
+            scope=data.get("scope"),
+        )
+
+    async def get_user_info(self, access_token: str) -> dict[str, object]:
+        """Fetch the Auth0 user profile associated with the access token."""
+
+        if not access_token:
+            raise Auth0Error("Access token is required to fetch user info")
+
+        headers = {"Authorization": f"Bearer {access_token}"}
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"{self.base_url}/userinfo",
+                headers=headers,
+                timeout=httpx.Timeout(10.0),
+            )
+
+        if response.status_code >= 400:
+            raise Auth0Error(
+                f"Auth0 userinfo request failed ({response.status_code}): {response.text}"
+            )
+
+        return response.json()

--- a/backend/app/services/payments.py
+++ b/backend/app/services/payments.py
@@ -1,0 +1,97 @@
+"""Payment processing integrations."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import stripe
+
+
+class StripePaymentError(Exception):
+    """Raised when Stripe operations fail."""
+
+
+class StripeConfigurationError(StripePaymentError):
+    """Raised when the Stripe client is missing required configuration."""
+
+
+@dataclass(slots=True)
+class CheckoutSession:
+    """Serializable representation of a Stripe Checkout session."""
+
+    session_id: str
+    url: str
+
+
+class StripePaymentProcessor:
+    """Wrapper around the Stripe SDK for creating checkout sessions."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        default_price_id: str | None = None,
+        default_success_url: str | None = None,
+        default_cancel_url: str | None = None,
+        default_mode: str = "subscription",
+    ) -> None:
+        if not api_key:
+            raise StripeConfigurationError("Stripe API key must be provided")
+
+        self._api_key = api_key
+        self._default_price_id = default_price_id
+        self._default_success_url = default_success_url
+        self._default_cancel_url = default_cancel_url
+        self._default_mode = default_mode
+
+    async def create_checkout_session(
+        self,
+        *,
+        price_id: str | None = None,
+        quantity: int = 1,
+        success_url: str | None = None,
+        cancel_url: str | None = None,
+        customer_email: str | None = None,
+        mode: str | None = None,
+    ) -> CheckoutSession:
+        """Create a Stripe Checkout session and return its identifiers."""
+
+        resolved_price_id = price_id or self._default_price_id
+        if not resolved_price_id:
+            raise StripeConfigurationError(
+                "A price ID must be provided either in the request or settings"
+            )
+
+        resolved_success = success_url or self._default_success_url
+        resolved_cancel = cancel_url or self._default_cancel_url
+        if not resolved_success or not resolved_cancel:
+            raise StripeConfigurationError(
+                "Success and cancel URLs must be provided either in the request or settings"
+            )
+
+        stripe.api_key = self._api_key
+
+        def _create_session() -> stripe.checkout.Session:
+            return stripe.checkout.Session.create(
+                mode=mode or self._default_mode,
+                line_items=[
+                    {
+                        "price": resolved_price_id,
+                        "quantity": quantity,
+                    }
+                ],
+                success_url=resolved_success,
+                cancel_url=resolved_cancel,
+                customer_email=customer_email,
+            )
+
+        try:
+            session: stripe.checkout.Session = await asyncio.to_thread(_create_session)
+        except stripe.error.StripeError as exc:  # type: ignore[attr-defined]
+            raise StripePaymentError(str(exc)) from exc
+
+        if not session.url:
+            raise StripePaymentError("Stripe did not return a checkout URL")
+
+        return CheckoutSession(session_id=session.id, url=session.url)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,6 +14,7 @@ pydantic = "^2.7.1"
 pydantic-settings = "^2.2.1"
 python-dotenv = "^1.0.1"
 httpx = "^0.27.0"
+stripe = "^9.5.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.2"


### PR DESCRIPTION
## Summary
- add Auth0-powered login endpoints that generate authorization URLs, exchange codes for tokens, and fetch user profiles
- integrate Stripe to create hosted Checkout sessions via a reusable payment processor
- document the new configuration required for authentication and payments and add the Stripe SDK dependency

## Testing
- poetry run pytest *(fails: module import path for `app` in existing tests is not configured in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8276482e88327a6cfd3bc7e001328