### PR TITLE
Add note taking UI and backend pipeline for audio annotations

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -4,7 +4,9 @@ from fastapi import HTTPException
 
 from app.core.config import Settings, get_settings as _get_settings
 from app.services.emotion import EmotionAnalyzer
+from app.services.note import NoteAnnotator
 from app.services.realtime import RealtimeSessionClient
+from app.services.storage import S3AudioStorage, StorageServiceError
 
 
 def get_settings() -> Settings:
@@ -39,4 +41,33 @@ def get_realtime_client() -> RealtimeSessionClient:
         model=settings.openai_realtime_model,
         voice=settings.openai_realtime_voice,
         instructions=settings.openai_realtime_instructions,
+    )
+
+
+@lru_cache
+def _get_audio_storage() -> S3AudioStorage:
+    settings = _get_settings()
+    return S3AudioStorage(settings)
+
+
+def get_audio_storage() -> S3AudioStorage:
+    """Return the configured audio storage backend."""
+
+    try:
+        return _get_audio_storage()
+    except StorageServiceError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+def get_note_annotator() -> NoteAnnotator:
+    """Return a configured note annotation client."""
+
+    settings = _get_settings()
+    if not settings.openai_api_key:
+        raise HTTPException(status_code=503, detail="Annotation service is not configured")
+
+    return NoteAnnotator(
+        api_key=settings.openai_api_key,
+        base_url=settings.openai_api_base_url,
+        model=settings.openai_annotation_model,
     )

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,10 +1,17 @@
 import base64
 import binascii
 from datetime import datetime, timezone
+from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from app.api.dependencies import get_emotion_analyzer, get_realtime_client, get_settings
+from app.api.dependencies import (
+    get_audio_storage,
+    get_emotion_analyzer,
+    get_note_annotator,
+    get_realtime_client,
+    get_settings,
+)
 from app.core.config import Settings
 from app.schemas.emotion import EmotionAnalysisRequest, EmotionAnalysisResponse
 from app.schemas.health import HealthResponse
@@ -13,8 +20,11 @@ from app.schemas.realtime import (
     VisionFrameRequest,
     VisionFrameResponse,
 )
+from app.schemas.note import NoteCreateRequest, NoteCreateResponse
 from app.services.emotion import EmotionAnalyzer
+from app.services.note import NoteAnnotator, NoteAnnotationError
 from app.services.realtime import RealtimeSessionClient, RealtimeSessionError
+from app.services.storage import S3AudioStorage, StorageServiceError
 
 router = APIRouter()
 
@@ -77,4 +87,47 @@ async def accept_vision_frame(payload: VisionFrameRequest) -> VisionFrameRespons
         bytes=len(decoded),
         captured_at=payload.captured_at,
         received_at=received_at,
+    )
+
+
+@router.post("/notes", response_model=NoteCreateResponse, tags=["notes"])
+async def create_note(
+    payload: NoteCreateRequest,
+    storage: S3AudioStorage = Depends(get_audio_storage),
+    annotator: NoteAnnotator = Depends(get_note_annotator),
+) -> NoteCreateResponse:
+    """Persist a note and request an annotated summary."""
+
+    audio_url: str | None = None
+    if payload.audio_base64:
+        try:
+            audio_bytes = base64.b64decode(payload.audio_base64, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise HTTPException(status_code=400, detail="Invalid base64-encoded audio clip") from exc
+
+        try:
+            upload = storage.upload_audio(audio_bytes, payload.audio_mime_type)
+        except StorageServiceError as exc:
+            raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+        audio_url = upload.url
+
+    try:
+        annotation = await annotator.annotate(
+            title=payload.title,
+            content=payload.content,
+            audio_url=audio_url,
+        )
+    except NoteAnnotationError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    created_at = datetime.now(timezone.utc)
+
+    return NoteCreateResponse(
+        note_id=str(uuid4()),
+        title=payload.title,
+        content=payload.content,
+        audio_url=audio_url,
+        annotation=annotation.content,
+        created_at=created_at,
     )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -20,6 +20,15 @@ class Settings(BaseSettings):
     openai_realtime_instructions: str | None = Field(
         default=None, alias="OPENAI_REALTIME_INSTRUCTIONS"
     )
+    openai_annotation_model: str = Field(
+        default="gpt-5.0", alias="OPENAI_ANNOTATION_MODEL"
+    )
+    aws_access_key_id: str | None = Field(default=None, alias="AWS_ACCESS_KEY_ID")
+    aws_secret_access_key: str | None = Field(
+        default=None, alias="AWS_SECRET_ACCESS_KEY"
+    )
+    aws_region_name: str | None = Field(default=None, alias="AWS_REGION")
+    aws_s3_bucket: str | None = Field(default=None, alias="AWS_S3_BUCKET")
 
     model_config = {
         "env_file": ".env",

--- a/backend/app/schemas/note.py
+++ b/backend/app/schemas/note.py
@@ -1,0 +1,31 @@
+"""Schemas for the note taking workflow."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class NoteCreateRequest(BaseModel):
+    """Payload for creating a note with optional audio recording."""
+
+    title: str = Field(..., description="Short title for the note")
+    content: str = Field(..., description="Free-form note contents")
+    audio_base64: Optional[str] = Field(
+        default=None, description="Base64 encoded audio blob in webm or wav format"
+    )
+    audio_mime_type: Optional[str] = Field(
+        default=None, description="MIME type of the provided audio clip"
+    )
+
+
+class NoteCreateResponse(BaseModel):
+    """Response returned after storing the note and annotation."""
+
+    note_id: str
+    title: str
+    content: str
+    audio_url: Optional[str]
+    annotation: str
+    created_at: datetime
+

--- a/backend/app/services/note.py
+++ b/backend/app/services/note.py
@@ -1,0 +1,82 @@
+"""Services for note processing and annotation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import httpx
+
+
+class NoteAnnotationError(RuntimeError):
+    """Raised when the annotation service fails."""
+
+
+@dataclass
+class AnnotationResult:
+    """Holds the annotation returned by the language model."""
+
+    content: str
+
+
+class NoteAnnotator:
+    """Call the OpenAI API (GPT-5) to annotate user notes."""
+
+    def __init__(self, api_key: str, base_url: str, model: str) -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._model = model
+
+    async def annotate(
+        self,
+        *,
+        title: str,
+        content: str,
+        audio_url: str | None,
+    ) -> AnnotationResult:
+        """Request an annotation summary for the provided note."""
+
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+        system_lines = [
+            "You are an expert research assistant that organizes meeting notes.",
+            "Provide a concise annotated summary, key action items, and follow-up questions.",
+        ]
+        if audio_url:
+            system_lines.append(
+                "An audio recording of the conversation is available at the following URL for additional context:"
+            )
+            system_lines.append(audio_url)
+
+        payload = {
+            "model": self._model,
+            "messages": [
+                {"role": "system", "content": "\n".join(system_lines)},
+                {
+                    "role": "user",
+                    "content": f"Title: {title}\n\n{content}",
+                },
+            ],
+        }
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            try:
+                response = await client.post(
+                    f"{self._base_url}/chat/completions", json=payload, headers=headers
+                )
+                response.raise_for_status()
+            except httpx.HTTPError as exc:  # pragma: no cover - network errors not deterministic
+                raise NoteAnnotationError("Failed to contact the annotation service") from exc
+
+        data = response.json()
+        try:
+            message = data["choices"][0]["message"]["content"].strip()
+        except (KeyError, IndexError, TypeError) as exc:
+            raise NoteAnnotationError("Unexpected response from annotation service") from exc
+
+        return AnnotationResult(content=message)
+
+
+__all__ = ["AnnotationResult", "NoteAnnotator", "NoteAnnotationError"]
+

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -1,0 +1,69 @@
+"""Storage service abstraction for persisting audio recordings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import uuid4
+
+import boto3
+
+from app.core.config import Settings
+
+
+class StorageServiceError(RuntimeError):
+    """Base exception for storage failures."""
+
+
+@dataclass
+class AudioUploadResult:
+    """Metadata returned after uploading an audio object."""
+
+    url: str
+    key: str
+
+
+class S3AudioStorage:
+    """Persist audio blobs to an Amazon S3 bucket."""
+
+    def __init__(self, settings: Settings) -> None:
+        if not settings.aws_s3_bucket:
+            raise StorageServiceError("AWS_S3_BUCKET is not configured")
+
+        session_kwargs: dict[str, str] = {}
+        if settings.aws_access_key_id and settings.aws_secret_access_key:
+            session_kwargs["aws_access_key_id"] = settings.aws_access_key_id
+            session_kwargs["aws_secret_access_key"] = settings.aws_secret_access_key
+        if settings.aws_region_name:
+            session_kwargs["region_name"] = settings.aws_region_name
+
+        self._bucket = settings.aws_s3_bucket
+        self._region = settings.aws_region_name
+        self._client = boto3.client("s3", **session_kwargs)
+
+    def upload_audio(
+        self,
+        payload: bytes,
+        content_type: str | None = None,
+    ) -> AudioUploadResult:
+        """Upload the given bytes to S3 and return the object location."""
+
+        key = f"recordings/{uuid4().hex}.webm"
+        extra_args: dict[str, str] = {}
+        if content_type:
+            extra_args["ContentType"] = content_type
+
+        try:
+            self._client.put_object(Bucket=self._bucket, Key=key, Body=payload, **extra_args)
+        except Exception as exc:  # pragma: no cover - boto3 raises many specific errors
+            raise StorageServiceError("Failed to upload audio to S3") from exc
+
+        if self._region:
+            url = f"https://{self._bucket}.s3.{self._region}.amazonaws.com/{key}"
+        else:
+            url = f"https://{self._bucket}.s3.amazonaws.com/{key}"
+
+        return AudioUploadResult(url=url, key=key)
+
+
+__all__ = ["AudioUploadResult", "S3AudioStorage", "StorageServiceError"]
+

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -78,6 +78,46 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "boto3"
+version = "1.40.40"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "boto3-1.40.40-py3-none-any.whl", hash = "sha256:385904de68623e1c341bdc095d94a30006843032c912adeb1e0752a343632ec6"},
+    {file = "boto3-1.40.40.tar.gz", hash = "sha256:f384d3a0410d0f1a4d4ae7aa69c41d0549c6ca5a76667dc25fc97d50ad6db740"},
+]
+
+[package.dependencies]
+botocore = ">=1.40.40,<1.41.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.14.0,<0.15.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.40.40"
+description = "Low-level, data-driven core of boto 3."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "botocore-1.40.40-py3-none-any.whl", hash = "sha256:68506142b3cde93145ef3ee0268f2444f2b68ada225a151f714092bbd3d6516a"},
+    {file = "botocore-1.40.40.tar.gz", hash = "sha256:78eb121a16a6481ed0f6e1aebe53a4f23aa121f34466846c13a5ca48fa980e31"},
+]
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""}
+
+[package.extras]
+crt = ["awscrt (==0.27.6)"]
+
+[[package]]
 name = "certifi"
 version = "2025.8.3"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -361,6 +401,18 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "jmespath"
+version = "1.0.1"
+description = "JSON Matching Expressions"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
+    {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
+]
 
 [[package]]
 name = "markdown-it-py"
@@ -734,6 +786,21 @@ pygments = ">=2.7.2"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -900,6 +967,24 @@ files = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.14.0"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "s3transfer-0.14.0-py3-none-any.whl", hash = "sha256:ea3b790c7077558ed1f02a3072fb3cb992bbbd253392f4b6e9e8976941c7d456"},
+    {file = "s3transfer-0.14.0.tar.gz", hash = "sha256:eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125"},
+]
+
+[package.dependencies]
+botocore = ">=1.37.4,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.37.4,<2.0a.0)"]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 description = "Tool to Detect Surrounding Shell"
@@ -909,6 +994,18 @@ groups = ["main"]
 files = [
     {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
     {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
 ]
 
 [[package]]
@@ -985,6 +1082,24 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.12.0"
+
+[[package]]
+name = "urllib3"
+version = "2.5.0"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
+    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
+]
+
+[package.extras]
+brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\""]
+h2 = ["h2 (>=4,<5)"]
+socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "uvicorn"
@@ -1266,4 +1381,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "e5986e66dd10167236b17bdc3c7522765026e9499f860b823f10c4d49ccc994b"
+content-hash = "63ee916a3279b1e6e91719d2dcc09518ee8c0ca9f7c36c37889dea47bb052e5f"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,6 +14,7 @@ pydantic = "^2.7.1"
 pydantic-settings = "^2.2.1"
 python-dotenv = "^1.0.1"
 httpx = "^0.27.0"
+boto3 = "^1.34.144"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.2"

--- a/frontend/app/notes/page.tsx
+++ b/frontend/app/notes/page.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
+
+type NoteResponse = {
+  note_id: string;
+  title: string;
+  content: string;
+  audio_url?: string | null;
+  annotation: string;
+  created_at: string;
+};
+
+type RecordingState = "idle" | "recording" | "processing";
+
+const blobToBase64 = async (blob: Blob): Promise<string> => {
+  const arrayBuffer = await blob.arrayBuffer();
+  const bytes = new Uint8Array(arrayBuffer);
+  let binary = "";
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary);
+};
+
+export default function NotesPage(): JSX.Element {
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [annotation, setAnnotation] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [recordingState, setRecordingState] = useState<RecordingState>("idle");
+  const [audioPreviewUrl, setAudioPreviewUrl] = useState<string | null>(null);
+  const [audioBase64, setAudioBase64] = useState<string | null>(null);
+  const [audioMimeType, setAudioMimeType] = useState<string | null>(null);
+
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<BlobPart[]>([]);
+
+  const isReadyToSubmit = useMemo(() => {
+    return title.trim().length > 0 && content.trim().length > 0 && !isSubmitting;
+  }, [title, content, isSubmitting]);
+
+  const startRecording = useCallback(async () => {
+    if (recordingState === "recording") return;
+    setError(null);
+
+    try {
+      if (audioPreviewUrl) {
+        URL.revokeObjectURL(audioPreviewUrl);
+        setAudioPreviewUrl(null);
+      }
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const mediaRecorder = new MediaRecorder(stream);
+      chunksRef.current = [];
+
+      mediaRecorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          chunksRef.current.push(event.data);
+        }
+      };
+
+      mediaRecorder.onstop = async () => {
+        setRecordingState("processing");
+        const blob = new Blob(chunksRef.current, { type: mediaRecorder.mimeType });
+        chunksRef.current = [];
+        setAudioMimeType(mediaRecorder.mimeType);
+        const base64 = await blobToBase64(blob);
+        setAudioBase64(base64);
+        const previewUrl = URL.createObjectURL(blob);
+        setAudioPreviewUrl(previewUrl);
+        setRecordingState("idle");
+      };
+
+      mediaRecorderRef.current = mediaRecorder;
+      mediaRecorder.start();
+      setRecordingState("recording");
+    } catch (err) {
+      console.error(err);
+      setError("Unable to access the microphone. Please grant permission and try again.");
+      setRecordingState("idle");
+    }
+  }, [audioPreviewUrl, recordingState]);
+
+  const stopRecording = useCallback(() => {
+    const recorder = mediaRecorderRef.current;
+    if (!recorder || recorder.state !== "recording") return;
+    recorder.stop();
+    recorder.stream.getTracks().forEach((track) => track.stop());
+    mediaRecorderRef.current = null;
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!isReadyToSubmit) return;
+      setIsSubmitting(true);
+      setError(null);
+      setAnnotation(null);
+
+      try {
+        const payload: Record<string, unknown> = {
+          title: title.trim(),
+          content: content.trim(),
+        };
+        if (audioBase64) {
+          payload["audio_base64"] = audioBase64;
+        }
+        if (audioMimeType) {
+          payload["audio_mime_type"] = audioMimeType;
+        }
+
+        const response = await fetch(`${API_BASE}/notes`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+          const message = await response.text();
+          throw new Error(message || "Failed to save note");
+        }
+
+        const data: NoteResponse = await response.json();
+        setAnnotation(data.annotation);
+      } catch (err) {
+        console.error(err);
+        setError(
+          err instanceof Error
+            ? err.message
+            : "An unexpected error occurred while saving the note."
+        );
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [audioBase64, audioMimeType, content, isReadyToSubmit, title]
+  );
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <header className="border-b border-slate-800 bg-slate-900/60 backdrop-blur">
+        <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-4">
+          <h1 className="text-xl font-semibold">AI Notes Workspace</h1>
+          <nav className="space-x-4 text-sm text-slate-400">
+            <Link href="/" className="hover:text-slate-100">
+              Home
+            </Link>
+            <span className="text-slate-700">/</span>
+            <span className="text-slate-100">Notes</span>
+          </nav>
+        </div>
+      </header>
+
+      <main className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-10">
+        <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-6 shadow-lg">
+          <h2 className="text-lg font-semibold">Capture your thoughts</h2>
+          <p className="mt-1 text-sm text-slate-400">
+            Draft notes, add a supporting voice memo, and let GPT-5 organize the takeaways for you.
+          </p>
+
+          <form className="mt-6 space-y-6" onSubmit={handleSubmit}>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-200" htmlFor="title">
+                Note title
+              </label>
+              <input
+                id="title"
+                name="title"
+                type="text"
+                required
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                className="w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/50"
+                placeholder="Product sync with design team"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-200" htmlFor="content">
+                Notes
+              </label>
+              <textarea
+                id="content"
+                name="content"
+                required
+                value={content}
+                onChange={(event) => setContent(event.target.value)}
+                rows={6}
+                className="w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm leading-6 outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/50"
+                placeholder="Capture decisions, blockers, and follow-ups..."
+              />
+            </div>
+
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <h3 className="text-sm font-medium text-slate-200">Voice memo</h3>
+                  <p className="text-xs text-slate-400">
+                    Start a quick recording to give GPT-5 richer context.
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    disabled={recordingState === "recording"}
+                    onClick={startRecording}
+                  >
+                    Start recording
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    disabled={recordingState !== "recording"}
+                    onClick={stopRecording}
+                  >
+                    Stop
+                  </Button>
+                </div>
+              </div>
+
+              <div className="rounded-md border border-dashed border-slate-700 bg-slate-950/50 p-4 text-sm">
+                {recordingState === "recording" && (
+                  <p className="text-amber-400">Recording in progress... speak freely!</p>
+                )}
+                {recordingState === "processing" && (
+                  <p className="text-indigo-400">Processing audio…</p>
+                )}
+                {recordingState === "idle" && !audioPreviewUrl && (
+                  <p className="text-slate-400">No audio attached yet.</p>
+                )}
+                {audioPreviewUrl && (
+                  <div className="space-y-2">
+                    <audio controls src={audioPreviewUrl} className="w-full" />
+                    <p className="text-xs text-slate-500">
+                      Audio will be stored securely in your configured AWS S3 bucket.
+                    </p>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between">
+              <div className="text-sm text-slate-500">
+                {error && <span className="text-rose-400">{error}</span>}
+                {!error && annotation && <span className="text-emerald-400">Annotation ready!</span>}
+              </div>
+              <Button type="submit" disabled={!isReadyToSubmit}>
+                {isSubmitting ? "Generating annotation…" : "Save note & annotate"}
+              </Button>
+            </div>
+          </form>
+        </section>
+
+        {annotation && (
+          <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-6 shadow-lg">
+            <h2 className="text-lg font-semibold">GPT-5 annotation</h2>
+            <p className="mt-3 whitespace-pre-line text-sm leading-6 text-slate-200">
+              {annotation}
+            </p>
+          </section>
+        )}
+      </main>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add configuration and services for storing audio recordings in S3 and sending notes to GPT-5 for annotation
- expose a new `/api/v1/notes` endpoint that uploads audio, triggers GPT-5 annotations, and returns structured metadata
- create a `/notes` Next.js route with a note editor, audio recorder, and annotation display tied to the new backend API

## Testing
- PYTHONPATH=. poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8272b42288327919c3befed9774ea