### PR TITLE
Add GPT-5 tutor mode API route with structured orchestration

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -5,6 +5,7 @@ from fastapi import HTTPException
 from app.core.config import Settings, get_settings as _get_settings
 from app.services.emotion import EmotionAnalyzer
 from app.services.realtime import RealtimeSessionClient
+from app.services.tutor import TutorModeService
 
 
 def get_settings() -> Settings:
@@ -40,3 +41,21 @@ def get_realtime_client() -> RealtimeSessionClient:
         voice=settings.openai_realtime_voice,
         instructions=settings.openai_realtime_instructions,
     )
+
+
+@lru_cache
+def _get_tutor_service() -> TutorModeService:
+    """Return a singleton tutor mode service configured from settings."""
+
+    settings = _get_settings()
+    return TutorModeService(
+        api_key=settings.openai_api_key,
+        base_url=settings.openai_api_base_url,
+        model="gpt-5",
+    )
+
+
+def get_tutor_service() -> TutorModeService:
+    """FastAPI dependency wrapper around the tutor service singleton."""
+
+    return _get_tutor_service()

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -4,7 +4,12 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from app.api.dependencies import get_emotion_analyzer, get_realtime_client, get_settings
+from app.api.dependencies import (
+    get_emotion_analyzer,
+    get_realtime_client,
+    get_settings,
+    get_tutor_service,
+)
 from app.core.config import Settings
 from app.schemas.emotion import EmotionAnalysisRequest, EmotionAnalysisResponse
 from app.schemas.health import HealthResponse
@@ -13,8 +18,10 @@ from app.schemas.realtime import (
     VisionFrameRequest,
     VisionFrameResponse,
 )
+from app.schemas.tutor import TutorModeRequest, TutorModeResponse
 from app.services.emotion import EmotionAnalyzer
 from app.services.realtime import RealtimeSessionClient, RealtimeSessionError
+from app.services.tutor import TutorModeService
 
 router = APIRouter()
 
@@ -78,3 +85,13 @@ async def accept_vision_frame(payload: VisionFrameRequest) -> VisionFrameRespons
         captured_at=payload.captured_at,
         received_at=received_at,
     )
+
+
+@router.post("/tutor/mode", response_model=TutorModeResponse, tags=["tutor"])
+async def create_tutor_mode_plan(
+    payload: TutorModeRequest,
+    tutor_service: TutorModeService = Depends(get_tutor_service),
+) -> TutorModeResponse:
+    """Create a BabyAGI-inspired tutoring plan powered by GPT-5."""
+
+    return await tutor_service.generate_plan(payload)

--- a/backend/app/schemas/tutor.py
+++ b/backend/app/schemas/tutor.py
@@ -1,0 +1,96 @@
+"""Pydantic models for the Tutor Mode feature."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class TutorModeRequest(BaseModel):
+    """Incoming payload describing the tutoring objective."""
+
+    topic: str = Field(..., description="Subject or concept the learner wants to explore")
+    student_level: str | None = Field(
+        default=None,
+        description="Quick description of the learner's current understanding",
+    )
+    goals: list[str] | None = Field(
+        default=None,
+        description="Learning goals or outcomes the learner cares about",
+    )
+    preferred_modalities: list[str] | None = Field(
+        default=None,
+        description="Modalities that resonate with the learner (e.g. visuals, demos)",
+    )
+    additional_context: str | None = Field(
+        default=None,
+        description="Any extra context that can help the tutor personalize the plan",
+    )
+
+
+class TutorUnderstandingPlan(BaseModel):
+    """Step 0 – capture how the tutor will gauge the learner's level."""
+
+    approach: str
+    diagnostic_questions: list[str]
+    signals_to_watch: list[str]
+
+
+class TutorConceptBreakdown(BaseModel):
+    """Step 1 – structured concepts and reasoning."""
+
+    concept: str
+    llm_reasoning: str
+    subtopics: list[str]
+    real_world_connections: list[str]
+
+
+class TutorTeachingModality(BaseModel):
+    """Step 2 – multi-modal explanation strategy."""
+
+    modality: Literal["visual", "verbal", "interactive", "experiential", "reading", "other"]
+    description: str
+    resources: list[str]
+
+
+class TutorAssessmentItem(BaseModel):
+    """Single assessment artifact for Step 3."""
+
+    prompt: str
+    kind: Literal["multiple_choice", "short_answer", "reflection", "practical"]
+    options: list[str] | None = None
+    answer_key: str | None = None
+
+
+class TutorAssessmentPlan(BaseModel):
+    """Step 3 – checks for understanding with human-in-the-loop guidance."""
+
+    title: str
+    format: str
+    human_in_the_loop_notes: str
+    items: list[TutorAssessmentItem]
+
+
+class TutorCompletionPlan(BaseModel):
+    """Step 4 – how the agent knows instruction is complete."""
+
+    mastery_indicators: list[str]
+    wrap_up_plan: str
+    follow_up_suggestions: list[str]
+
+
+class TutorModeResponse(BaseModel):
+    """Comprehensive tutor mode plan returned to clients."""
+
+    model: str = Field(description="Model powering the plan")
+    generated_at: datetime
+    topic: str
+    learner_profile: str
+    objectives: list[str]
+    understanding: TutorUnderstandingPlan
+    concept_breakdown: list[TutorConceptBreakdown]
+    teaching_modalities: list[TutorTeachingModality]
+    assessment: TutorAssessmentPlan
+    completion: TutorCompletionPlan

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,5 +1,6 @@
 """Service layer exports."""
 
 from .emotion import EmotionAnalyzer, EmotionTaxonomy
+from .tutor import TutorModeService
 
-__all__ = ["EmotionAnalyzer", "EmotionTaxonomy"]
+__all__ = ["EmotionAnalyzer", "EmotionTaxonomy", "TutorModeService"]

--- a/backend/app/services/tutor.py
+++ b/backend/app/services/tutor.py
@@ -1,0 +1,278 @@
+"""Tutor mode orchestration powered by GPT-5 (with graceful fallbacks)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from textwrap import dedent
+from typing import Any
+
+import httpx
+
+from app.schemas.tutor import (
+    TutorAssessmentItem,
+    TutorAssessmentPlan,
+    TutorCompletionPlan,
+    TutorConceptBreakdown,
+    TutorModeRequest,
+    TutorModeResponse,
+    TutorTeachingModality,
+    TutorUnderstandingPlan,
+)
+
+
+class TutorModeService:
+    """Generate an agentic tutoring plan using GPT-5 or an offline heuristic."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None,
+        base_url: str,
+        model: str,
+        timeout: float = 30.0,
+    ) -> None:
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.timeout = timeout
+
+    async def generate_plan(self, payload: TutorModeRequest) -> TutorModeResponse:
+        """Return a structured tutor plan, attempting GPT-5 first."""
+
+        if not self.api_key:
+            return self._offline_plan(payload)
+
+        try:
+            response_json = await self._call_openai(payload)
+            return self._from_openai(payload, response_json)
+        except Exception:
+            return self._offline_plan(payload)
+
+    async def _call_openai(self, payload: TutorModeRequest) -> dict[str, Any]:
+        """Invoke the OpenAI Responses API requesting a JSON plan."""
+
+        prompt = dedent(
+            f"""
+            You are BabyAGI operating in tutor mode and powered by {self.model}. The
+            student profile is described below. Produce a tutoring game plan as JSON
+            following the `tutor_plan` schema.
+
+            Student profile:
+            - Topic: {payload.topic}
+            - Student level: {payload.student_level or 'unspecified'}
+            - Goals: {', '.join(payload.goals or ['not provided'])}
+            - Preferred modalities: {', '.join(payload.preferred_modalities or ['not provided'])}
+            - Additional context: {payload.additional_context or 'none'}
+
+            The JSON schema (tutor_plan) must contain:
+            {{
+              "model": string,
+              "learner_profile": string,
+              "objectives": string array,
+              "understanding": {{
+                "approach": string,
+                "diagnostic_questions": string array,
+                "signals_to_watch": string array
+              }},
+              "concept_breakdown": array of {{
+                "concept": string,
+                "llm_reasoning": string,
+                "subtopics": string array,
+                "real_world_connections": string array
+              }},
+              "teaching_modalities": array of {{
+                "modality": string,
+                "description": string,
+                "resources": string array
+              }},
+              "assessment": {{
+                "title": string,
+                "format": string,
+                "human_in_the_loop_notes": string,
+                "items": array of {{
+                  "prompt": string,
+                  "kind": string,
+                  "options": string array or null,
+                  "answer_key": string or null
+                }}
+              }},
+              "completion": {{
+                "mastery_indicators": string array,
+                "wrap_up_plan": string,
+                "follow_up_suggestions": string array
+              }}
+            }}
+
+            Ensure the plan emphasises human-in-the-loop checkpoints.
+            """
+        ).strip()
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        body: dict[str, Any] = {
+            "model": self.model,
+            "input": prompt,
+            "response_format": {"type": "json_object"},
+        }
+
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            response = await client.post(
+                f"{self.base_url}/responses", headers=headers, json=body
+            )
+        response.raise_for_status()
+
+        data = response.json()
+        # The Responses API returns JSON content in various spots; prefer direct JSON.
+        if isinstance(data, dict) and "output" in data:
+            for item in data.get("output", []):
+                if item.get("type") == "output_text":
+                    return httpx.Response(200, text=item.get("text", "{}"), request=response.request).json()
+        if isinstance(data, dict) and "output_text" in data:
+            return httpx.Response(200, text=data.get("output_text", "{}"), request=response.request).json()
+        if isinstance(data, dict) and "response" in data:
+            return data["response"]
+        return data
+
+    def _from_openai(
+        self, payload: TutorModeRequest, response_json: dict[str, Any]
+    ) -> TutorModeResponse:
+        """Convert OpenAI JSON into the API's typed response."""
+
+        # Defensive parsing: fall back to offline plan if required keys are missing.
+        required_keys = {
+            "learner_profile",
+            "objectives",
+            "understanding",
+            "concept_breakdown",
+            "teaching_modalities",
+            "assessment",
+            "completion",
+        }
+        if not required_keys.issubset(response_json):
+            return self._offline_plan(payload)
+
+        understanding = TutorUnderstandingPlan(**response_json["understanding"])
+        concepts = [
+            TutorConceptBreakdown(**concept)
+            for concept in response_json.get("concept_breakdown", [])
+        ]
+        modalities = [
+            TutorTeachingModality(**modality)
+            for modality in response_json.get("teaching_modalities", [])
+        ]
+        assessment_payload = response_json.get("assessment", {})
+        items = [
+            TutorAssessmentItem(**item)
+            for item in assessment_payload.get("items", [])
+        ]
+        assessment = TutorAssessmentPlan(**assessment_payload, items=items)
+        completion = TutorCompletionPlan(**response_json.get("completion", {}))
+
+        return TutorModeResponse(
+            model=response_json.get("model", self.model),
+            generated_at=datetime.now(timezone.utc),
+            topic=payload.topic,
+            learner_profile=response_json["learner_profile"],
+            objectives=response_json.get("objectives", []),
+            understanding=understanding,
+            concept_breakdown=concepts,
+            teaching_modalities=modalities,
+            assessment=assessment,
+            completion=completion,
+        )
+
+    def _offline_plan(self, payload: TutorModeRequest) -> TutorModeResponse:
+        """Provide a deterministic plan when GPT-5 cannot be reached."""
+
+        learner_profile = payload.student_level or "Curious learner"
+        objectives = payload.goals or [
+            f"Build foundational understanding of {payload.topic}",
+            "Practice applying the concept in context",
+        ]
+        understanding = TutorUnderstandingPlan(
+            approach="Start with a conversational diagnostic to gauge prior knowledge",
+            diagnostic_questions=[
+                f"How would you describe {payload.topic} in your own words?",
+                "Which parts feel confusing or intimidating right now?",
+            ],
+            signals_to_watch=[
+                "Confidence when answering why/how questions",
+                "Ability to connect the topic to prior knowledge",
+            ],
+        )
+        concept_breakdown = [
+            TutorConceptBreakdown(
+                concept=payload.topic,
+                llm_reasoning="Decompose the topic into digestible layers, building from fundamentals to nuanced applications.",
+                subtopics=[
+                    f"Core principles of {payload.topic}",
+                    "Key vocabulary and definitions",
+                    "Common pitfalls and misconceptions",
+                ],
+                real_world_connections=[
+                    f"Everyday scenarios where {payload.topic} shows up",
+                    "Analogies drawn from the learner's interests",
+                ],
+            )
+        ]
+        modalities = [
+            TutorTeachingModality(
+                modality="visual",
+                description="Use diagrams or flowcharts to map the relationships between subtopics.",
+                resources=["Whiteboard sketches", "Infographic summarising the big picture"],
+            ),
+            TutorTeachingModality(
+                modality="interactive",
+                description="Guide the learner through a short BabyAGI-style task list they complete with you.",
+                resources=["Collaborative document", "Step-by-step practice prompts"],
+            ),
+            TutorTeachingModality(
+                modality="verbal",
+                description="Offer a narrative explanation that stitches the ideas together with stories.",
+                resources=["Mini lecture outline", "Real-time Q&A"],
+            ),
+        ]
+        assessment_items = [
+            TutorAssessmentItem(
+                prompt=f"Explain {payload.topic} to a friend using a real-world analogy.",
+                kind="reflection",
+            ),
+            TutorAssessmentItem(
+                prompt=f"Apply {payload.topic} to solve a quick scenario provided by the mentor.",
+                kind="practical",
+                answer_key="Look for a structured approach and correct reasoning steps.",
+            ),
+        ]
+        assessment = TutorAssessmentPlan(
+            title=f"{payload.topic} comprehension check",
+            format="Conversational debrief with quick formative quiz",
+            human_in_the_loop_notes="Mentor reviews answers, probes for depth, and adapts follow-up tasks",
+            items=assessment_items,
+        )
+        completion = TutorCompletionPlan(
+            mastery_indicators=[
+                "Learner explains the concept clearly and accurately",
+                "Learner demonstrates transfer through a novel example",
+                "Learner identifies next steps or questions without prompting",
+            ],
+            wrap_up_plan="Summarise key insights together and document agreed action items in the shared workspace.",
+            follow_up_suggestions=[
+                "Schedule a follow-up micro-assessment in 48 hours",
+                "Provide curated resources aligned with preferred modalities",
+            ],
+        )
+
+        return TutorModeResponse(
+            model=self.model,
+            generated_at=datetime.now(timezone.utc),
+            topic=payload.topic,
+            learner_profile=learner_profile,
+            objectives=objectives,
+            understanding=understanding,
+            concept_breakdown=concept_breakdown,
+            teaching_modalities=modalities,
+            assessment=assessment,
+            completion=completion,
+        )

--- a/backend/tests/test_tutor.py
+++ b/backend/tests/test_tutor.py
@@ -1,0 +1,43 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_tutor_mode_offline_plan_structure() -> None:
+    """Tutor mode returns a rich plan even without an OpenAI API key."""
+
+    payload = {
+        "topic": "Neural Networks",
+        "student_level": "Beginner programmer transitioning into ML",
+        "goals": ["Understand core building blocks", "Implement a simple network"],
+        "preferred_modalities": ["visual", "interactive"],
+    }
+
+    with TestClient(app) as client:
+        response = client.post("/api/v1/tutor/mode", json=payload)
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["model"] == "gpt-5"
+    assert data["topic"] == payload["topic"]
+    assert data["learner_profile"]
+    assert data["objectives"]
+
+    understanding = data["understanding"]
+    assert understanding["diagnostic_questions"], "Expected diagnostic questions in plan"
+
+    concepts = data["concept_breakdown"]
+    assert isinstance(concepts, list) and len(concepts) >= 1
+    assert concepts[0]["llm_reasoning"]
+
+    modalities = data["teaching_modalities"]
+    assert {modality["modality"] for modality in modalities} >= {"visual", "interactive", "verbal"}
+
+    assessment = data["assessment"]
+    assert assessment["human_in_the_loop_notes"]
+    assert any(item["kind"] == "practical" for item in assessment["items"])
+
+    completion = data["completion"]
+    assert completion["mastery_indicators"]
+    assert completion["follow_up_suggestions"]


### PR DESCRIPTION
## Summary
- add tutor mode request/response schemas capturing the BabyAGI-inspired plan structure
- implement a TutorModeService that calls GPT-5 when available and gracefully falls back to a deterministic plan
- expose the new /api/v1/tutor/mode endpoint and add regression coverage for the offline plan output

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d827acc3448327828ae7d08b6aa43a