### PR TITLE
Add Auth0 authentication and Stripe payments endpoints

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -29,6 +29,17 @@ class Settings(BaseSettings):
     )
     aws_region_name: str | None = Field(default=None, alias="AWS_REGION")
     aws_s3_bucket: str | None = Field(default=None, alias="AWS_S3_BUCKET")
+    auth0_domain: str | None = Field(default=None, alias="AUTH0_DOMAIN")
+    auth0_client_id: str | None = Field(default=None, alias="AUTH0_CLIENT_ID")
+    auth0_client_secret: str | None = Field(
+        default=None, alias="AUTH0_CLIENT_SECRET"
+    )
+    auth0_audience: str | None = Field(default=None, alias="AUTH0_AUDIENCE")
+    stripe_secret_key: str | None = Field(default=None, alias="STRIPE_SECRET_KEY")
+    stripe_default_price_id: str | None = Field(
+        default=None, alias="STRIPE_DEFAULT_PRICE_ID"
+    )
+    stripe_mode: str = Field(default="subscription", alias="STRIPE_MODE")
 
     model_config = {
         "env_file": ".env",

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,0 +1,44 @@
+"""Pydantic schemas for authentication workflows."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from pydantic import BaseModel, EmailStr, Field, HttpUrl
+
+
+class AuthLoginResponse(BaseModel):
+    """Response returned when requesting an Auth0 login URL."""
+
+    authorization_url: HttpUrl = Field(..., description="Hosted Auth0 login URL")
+
+
+class AuthCallbackRequest(BaseModel):
+    """Payload sent from the client when exchanging an Auth0 code."""
+
+    code: str = Field(..., description="Authorization code issued by Auth0")
+    redirect_uri: HttpUrl = Field(..., description="Redirect URI used during login")
+
+
+class AuthTokenResponse(BaseModel):
+    """Tokens returned from Auth0's token endpoint."""
+
+    access_token: str
+    token_type: str
+    expires_in: int
+    scope: str | None = None
+    id_token: str | None = None
+    refresh_token: str | None = None
+
+
+class AuthUserInfoResponse(BaseModel):
+    """Subset of Auth0 user profile information."""
+
+    sub: str = Field(..., description="Auth0 user identifier")
+    email: EmailStr | None = None
+    name: str | None = None
+    picture: HttpUrl | None = None
+    claims: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Raw claims returned by Auth0 beyond standard fields",
+    )

--- a/backend/app/schemas/payment.py
+++ b/backend/app/schemas/payment.py
@@ -1,0 +1,26 @@
+"""Pydantic models for payment related endpoints."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, EmailStr, Field, HttpUrl, conint
+
+
+class PaymentCheckoutRequest(BaseModel):
+    """Request payload for creating a Stripe Checkout session."""
+
+    success_url: HttpUrl = Field(..., description="URL to redirect after successful payment")
+    cancel_url: HttpUrl = Field(..., description="URL to redirect if the user cancels")
+    price_id: str | None = Field(
+        default=None, description="Optional override for the Stripe price identifier"
+    )
+    quantity: conint(gt=0) = Field(default=1, description="Number of seats or units")
+    customer_email: EmailStr | None = Field(
+        default=None, description="Optional customer email for pre-filling Checkout"
+    )
+
+
+class PaymentCheckoutResponse(BaseModel):
+    """Response returned after creating a Stripe Checkout session."""
+
+    session_id: str = Field(..., description="Unique identifier for the Checkout session")
+    checkout_url: HttpUrl = Field(..., description="URL where the user can complete payment")

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,16 +1,25 @@
 """Service layer exports."""
 
+from .auth import Auth0Client, Auth0ClientError, AuthTokens, AuthUserInfo
 from .emotion import EmotionAnalyzer, EmotionTaxonomy
 from .note import AnnotationResult, NoteAnnotator, NoteAnnotationError
+from .payment import CheckoutSession, StripePaymentError, StripePaymentService
 from .storage import AudioUploadResult, S3AudioStorage, StorageServiceError
 from .tutor import TutorModeService
 
 __all__ = [
+    "Auth0Client",
+    "Auth0ClientError",
+    "AuthTokens",
+    "AuthUserInfo",
     "EmotionAnalyzer",
     "EmotionTaxonomy",
     "AnnotationResult",
     "NoteAnnotator",
     "NoteAnnotationError",
+    "CheckoutSession",
+    "StripePaymentService",
+    "StripePaymentError",
     "AudioUploadResult",
     "S3AudioStorage",
     "StorageServiceError",

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -1,0 +1,174 @@
+"""Auth0 service integration used for login flows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+from urllib.parse import urlencode
+
+import httpx
+
+
+class Auth0ClientError(RuntimeError):
+    """Raised when Auth0 returns an unexpected response."""
+
+
+@dataclass(slots=True)
+class AuthTokens:
+    """Structured representation of an Auth0 access token response."""
+
+    access_token: str
+    token_type: str
+    expires_in: int
+    scope: Optional[str] = None
+    id_token: Optional[str] = None
+    refresh_token: Optional[str] = None
+
+    @classmethod
+    def from_payload(cls, payload: Dict[str, Any]) -> "AuthTokens":
+        """Create an ``AuthTokens`` instance from an Auth0 token payload."""
+
+        try:
+            return cls(
+                access_token=payload["access_token"],
+                token_type=payload["token_type"],
+                expires_in=int(payload["expires_in"]),
+                scope=payload.get("scope"),
+                id_token=payload.get("id_token"),
+                refresh_token=payload.get("refresh_token"),
+            )
+        except KeyError as exc:  # pragma: no cover - defensive branch
+            missing = exc.args[0]
+            raise Auth0ClientError(f"Token response missing '{missing}' field") from exc
+
+
+@dataclass(slots=True)
+class AuthUserInfo:
+    """Representation of the user profile returned by Auth0."""
+
+    sub: str
+    email: Optional[str]
+    name: Optional[str]
+    picture: Optional[str]
+    raw: Dict[str, Any]
+
+    @classmethod
+    def from_payload(cls, payload: Dict[str, Any]) -> "AuthUserInfo":
+        """Instantiate from an Auth0 ``/userinfo`` payload."""
+
+        try:
+            subject = payload["sub"]
+        except KeyError as exc:  # pragma: no cover - defensive branch
+            raise Auth0ClientError("User info response missing 'sub'") from exc
+
+        return cls(
+            sub=subject,
+            email=payload.get("email"),
+            name=payload.get("name"),
+            picture=payload.get("picture"),
+            raw=payload,
+        )
+
+
+class Auth0Client:
+    """Small wrapper around Auth0's OAuth endpoints."""
+
+    def __init__(
+        self,
+        *,
+        domain: str,
+        client_id: str,
+        client_secret: str | None = None,
+        audience: str | None = None,
+        default_scope: str = "openid profile email",
+        timeout: float = 10.0,
+    ) -> None:
+        if not domain:
+            raise ValueError("Auth0 domain is required")
+
+        normalized_domain = domain.strip().rstrip("/")
+        if not normalized_domain.startswith("http://") and not normalized_domain.startswith(
+            "https://"
+        ):
+            normalized_domain = f"https://{normalized_domain}"
+
+        self.base_url = normalized_domain
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.audience = audience
+        self.default_scope = default_scope
+        self.timeout = timeout
+
+    def build_authorize_url(
+        self,
+        *,
+        redirect_uri: str,
+        state: str | None = None,
+        scope: str | None = None,
+        audience: str | None = None,
+    ) -> str:
+        """Return the hosted login page URL for initiating Auth0 login."""
+
+        params: Dict[str, Any] = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "redirect_uri": redirect_uri,
+            "scope": scope or self.default_scope,
+        }
+
+        final_audience = audience or self.audience
+        if final_audience:
+            params["audience"] = final_audience
+        if state:
+            params["state"] = state
+
+        query = urlencode({k: v for k, v in params.items() if v is not None})
+        return f"{self.base_url}/authorize?{query}"
+
+    async def exchange_code_for_tokens(self, *, code: str, redirect_uri: str) -> AuthTokens:
+        """Trade an authorization code for Auth0 tokens."""
+
+        token_url = f"{self.base_url}/oauth/token"
+        payload: Dict[str, Any] = {
+            "grant_type": "authorization_code",
+            "client_id": self.client_id,
+            "code": code,
+            "redirect_uri": redirect_uri,
+        }
+
+        if self.client_secret:
+            payload["client_secret"] = self.client_secret
+        if self.audience:
+            payload["audience"] = self.audience
+
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            response = await client.post(
+                token_url,
+                data=payload,
+                headers={"content-type": "application/x-www-form-urlencoded"},
+            )
+
+        if response.status_code >= 400:
+            message = response.text or response.reason_phrase
+            raise Auth0ClientError(
+                f"Auth0 token exchange failed with status {response.status_code}: {message}"
+            )
+
+        return AuthTokens.from_payload(response.json())
+
+    async def get_user_info(self, access_token: str) -> AuthUserInfo:
+        """Fetch the authenticated user's profile using the provided access token."""
+
+        url = f"{self.base_url}/userinfo"
+        headers = {"Authorization": f"Bearer {access_token}"}
+
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            response = await client.get(url, headers=headers)
+
+        if response.status_code >= 400:
+            message = response.text or response.reason_phrase
+            raise Auth0ClientError(
+                f"Auth0 user info request failed with status {response.status_code}: {message}"
+            )
+
+        return AuthUserInfo.from_payload(response.json())

--- a/backend/app/services/payment.py
+++ b/backend/app/services/payment.py
@@ -1,0 +1,79 @@
+"""Stripe payment helpers for creating Checkout sessions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import stripe
+
+
+class StripePaymentError(RuntimeError):
+    """Raised when the Stripe API returns an unexpected response."""
+
+
+@dataclass(slots=True)
+class CheckoutSession:
+    """Lightweight representation of a Stripe Checkout session."""
+
+    session_id: str
+    url: str
+
+
+class StripePaymentService:
+    """Wrapper around the Stripe SDK for creating Checkout sessions."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        default_price_id: str | None = None,
+        mode: str = "subscription",
+    ) -> None:
+        if not api_key:
+            raise ValueError("Stripe secret key is required")
+
+        self.api_key = api_key
+        self.default_price_id = default_price_id
+        self.mode = mode
+
+    def create_checkout_session(
+        self,
+        *,
+        success_url: str,
+        cancel_url: str,
+        price_id: str | None = None,
+        quantity: int = 1,
+        customer_email: str | None = None,
+    ) -> CheckoutSession:
+        """Create and return a hosted Stripe Checkout session."""
+
+        final_price_id = price_id or self.default_price_id
+        if not final_price_id:
+            raise StripePaymentError("Stripe price identifier is not configured")
+
+        if quantity <= 0:
+            raise StripePaymentError("Quantity must be greater than zero")
+
+        stripe.api_key = self.api_key
+
+        params: dict[str, object] = {
+            "mode": self.mode,
+            "success_url": success_url,
+            "cancel_url": cancel_url,
+            "line_items": [{"price": final_price_id, "quantity": quantity}],
+            "automatic_tax": {"enabled": True},
+        }
+        if customer_email:
+            params["customer_email"] = customer_email
+
+        try:
+            session = stripe.checkout.Session.create(**params)
+        except stripe.error.StripeError as exc:  # pragma: no cover - requires live Stripe
+            raise StripePaymentError(str(exc)) from exc
+
+        session_id = getattr(session, "id", None)
+        session_url = getattr(session, "url", None)
+        if not session_id or not session_url:
+            raise StripePaymentError("Stripe session response missing identifiers")
+
+        return CheckoutSession(session_id=session_id, url=session_url)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,6 +15,7 @@ pydantic-settings = "^2.2.1"
 python-dotenv = "^1.0.1"
 httpx = "^0.27.0"
 boto3 = "^1.34.144"
+stripe = "^8.9.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.2"

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,140 @@
+"""Tests covering the authentication endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.dependencies import get_auth_client
+from app.main import app
+from app.services.auth import Auth0Client, AuthTokens, AuthUserInfo
+
+
+class StubAuth0Client(Auth0Client):
+    """In-memory Auth0 stub that records method invocations."""
+
+    def __init__(self) -> None:  # type: ignore[no-untyped-def]
+        # Bypass parent initialisation since we're only stubbing behaviour.
+        pass
+
+    def build_authorize_url(  # type: ignore[override]
+        self,
+        *,
+        redirect_uri: str,
+        state: str | None = None,
+        scope: str | None = None,
+        audience: str | None = None,
+    ) -> str:
+        self.last_authorize_args = {
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "scope": scope,
+            "audience": audience,
+        }
+        return "https://auth0.example.com/authorize?client_id=abc"
+
+    async def exchange_code_for_tokens(  # type: ignore[override]
+        self,
+        *,
+        code: str,
+        redirect_uri: str,
+    ) -> AuthTokens:
+        self.last_exchange_args = {"code": code, "redirect_uri": redirect_uri}
+        return AuthTokens(
+            access_token="access-token",
+            token_type="Bearer",
+            expires_in=3600,
+            scope="openid profile",
+            id_token="id-token",
+            refresh_token="refresh-token",
+        )
+
+    async def get_user_info(self, access_token: str) -> AuthUserInfo:  # type: ignore[override]
+        self.last_user_info_token = access_token
+        return AuthUserInfo(
+            sub="auth0|123",
+            email="user@example.com",
+            name="Jane Doe",
+            picture="https://example.com/avatar.png",
+            raw={
+                "sub": "auth0|123",
+                "email": "user@example.com",
+                "name": "Jane Doe",
+                "picture": "https://example.com/avatar.png",
+                "locale": "en-US",
+            },
+        )
+
+
+@pytest.fixture()
+def stub_client() -> StubAuth0Client:
+    client = StubAuth0Client()
+    app.dependency_overrides[get_auth_client] = lambda: client
+    try:
+        yield client
+    finally:
+        app.dependency_overrides.pop(get_auth_client, None)
+
+
+@pytest.fixture()
+def client(stub_client: StubAuth0Client) -> TestClient:
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_auth_login_returns_authorize_url(client: TestClient, stub_client: StubAuth0Client) -> None:
+    response = client.get(
+        "/api/v1/auth/login",
+        params={"redirect_uri": "https://example.com/callback", "state": "xyz"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["authorization_url"] == "https://auth0.example.com/authorize?client_id=abc"
+    assert stub_client.last_authorize_args == {
+        "redirect_uri": "https://example.com/callback",
+        "state": "xyz",
+        "scope": None,
+        "audience": None,
+    }
+
+
+def test_auth_callback_exchanges_code_for_tokens(
+    client: TestClient, stub_client: StubAuth0Client
+) -> None:
+    response = client.post(
+        "/api/v1/auth/callback",
+        json={"code": "auth-code", "redirect_uri": "https://example.com/callback"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["access_token"] == "access-token"
+    assert body["token_type"] == "Bearer"
+    assert body["refresh_token"] == "refresh-token"
+    assert stub_client.last_exchange_args == {
+        "code": "auth-code",
+        "redirect_uri": "https://example.com/callback",
+    }
+
+
+def test_auth_user_info_requires_bearer_token(client: TestClient) -> None:
+    response = client.get("/api/v1/auth/user")
+
+    assert response.status_code == 422  # Missing header triggers validation error
+
+
+def test_auth_user_info_returns_profile(
+    client: TestClient, stub_client: StubAuth0Client
+) -> None:
+    response = client.get(
+        "/api/v1/auth/user",
+        headers={"Authorization": "Bearer access-token"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["sub"] == "auth0|123"
+    assert body["email"] == "user@example.com"
+    assert body["claims"]["locale"] == "en-US"
+    assert stub_client.last_user_info_token == "access-token"

--- a/backend/tests/test_payments.py
+++ b/backend/tests/test_payments.py
@@ -1,0 +1,92 @@
+"""Tests for the Stripe payment integration endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.dependencies import get_payment_service
+from app.main import app
+from app.services.payment import CheckoutSession, StripePaymentError, StripePaymentService
+
+
+class StubStripePaymentService(StripePaymentService):
+    """Stub payment service for testing without hitting Stripe."""
+
+    def __init__(self) -> None:  # type: ignore[no-untyped-def]
+        pass
+
+    def create_checkout_session(  # type: ignore[override]
+        self,
+        *,
+        success_url: str,
+        cancel_url: str,
+        price_id: str | None = None,
+        quantity: int = 1,
+        customer_email: str | None = None,
+    ) -> CheckoutSession:
+        self.last_call = {
+            "success_url": success_url,
+            "cancel_url": cancel_url,
+            "price_id": price_id,
+            "quantity": quantity,
+            "customer_email": customer_email,
+        }
+        if price_id == "error":
+            raise StripePaymentError("invalid price")
+        return CheckoutSession(session_id="cs_test_123", url="https://stripe.test/checkout")
+
+
+@pytest.fixture()
+def payment_stub() -> StubStripePaymentService:
+    stub = StubStripePaymentService()
+    app.dependency_overrides[get_payment_service] = lambda: stub
+    try:
+        yield stub
+    finally:
+        app.dependency_overrides.pop(get_payment_service, None)
+
+
+@pytest.fixture()
+def client(payment_stub: StubStripePaymentService) -> TestClient:
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_create_checkout_session_returns_session(
+    client: TestClient, payment_stub: StubStripePaymentService
+) -> None:
+    payload = {
+        "success_url": "https://example.com/success",
+        "cancel_url": "https://example.com/cancel",
+        "price_id": "price_123",
+        "quantity": 2,
+        "customer_email": "customer@example.com",
+    }
+    response = client.post("/api/v1/payments/checkout", json=payload)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["session_id"] == "cs_test_123"
+    assert body["checkout_url"] == "https://stripe.test/checkout"
+    assert payment_stub.last_call == {
+        "success_url": "https://example.com/success",
+        "cancel_url": "https://example.com/cancel",
+        "price_id": "price_123",
+        "quantity": 2,
+        "customer_email": "customer@example.com",
+    }
+
+
+def test_create_checkout_session_handles_errors(
+    client: TestClient, payment_stub: StubStripePaymentService
+) -> None:
+    payload = {
+        "success_url": "https://example.com/success",
+        "cancel_url": "https://example.com/cancel",
+        "price_id": "error",
+    }
+    response = client.post("/api/v1/payments/checkout", json=payload)
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "invalid price"


### PR DESCRIPTION
## Summary
- integrate Auth0 login flow with endpoints for initiating login, exchanging codes, and retrieving user info
- add a Stripe Checkout endpoint with supporting payment services and schemas
- extend configuration and tests to cover the new authentication and payment flows

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8380abc00832794965855a85e60ea