### PR TITLE
Add research discovery RAG endpoint with streaming UI

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -23,6 +23,14 @@ class Settings(BaseSettings):
     openai_annotation_model: str = Field(
         default="gpt-5.0", alias="OPENAI_ANNOTATION_MODEL"
     )
+    openai_research_model: str = Field(default="gpt-5.0", alias="OPENAI_RESEARCH_MODEL")
+    cohere_api_key: str | None = Field(default=None, alias="COHERE_API_KEY")
+    cohere_rerank_model: str = Field(
+        default="rerank-english-v3.0", alias="COHERE_RERANK_MODEL"
+    )
+    arxiv_index_path: str = Field(
+        default="app/data/arxiv_index.json", alias="ARXIV_INDEX_PATH"
+    )
     aws_access_key_id: str | None = Field(default=None, alias="AWS_ACCESS_KEY_ID")
     aws_secret_access_key: str | None = Field(
         default=None, alias="AWS_SECRET_ACCESS_KEY"

--- a/backend/app/data/arxiv_index.json
+++ b/backend/app/data/arxiv_index.json
@@ -1,0 +1,37 @@
+[
+  {
+    "paper_id": "2301.00001",
+    "title": "Scaling Instruction-Following with Large Language Models",
+    "summary": "We demonstrate techniques for aligning very large language models with human instructions using reinforcement learning and preference modeling.",
+    "url": "https://arxiv.org/abs/2301.00001",
+    "published": "2023-01-01"
+  },
+  {
+    "paper_id": "2212.12345",
+    "title": "Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks",
+    "summary": "This paper introduces a retrieval-augmented generator that combines dense vector search with generative transformers to answer knowledge-intensive questions.",
+    "url": "https://arxiv.org/abs/2212.12345",
+    "published": "2022-12-19"
+  },
+  {
+    "paper_id": "2403.01234",
+    "title": "Emergent Reasoning in Multimodal Foundation Models",
+    "summary": "We analyze how multimodal large language models develop grounded reasoning capabilities when trained jointly on text and vision corpora.",
+    "url": "https://arxiv.org/abs/2403.01234",
+    "published": "2024-03-04"
+  },
+  {
+    "paper_id": "2007.09876",
+    "title": "Quantum Advantage in Noisy Intermediate-Scale Quantum Devices",
+    "summary": "We survey algorithmic primitives that demonstrate quantum advantage on near-term quantum hardware and discuss error mitigation strategies.",
+    "url": "https://arxiv.org/abs/2007.09876",
+    "published": "2020-07-20"
+  },
+  {
+    "paper_id": "2109.54321",
+    "title": "Self-Supervised Representation Learning for Scientific Literature",
+    "summary": "The authors propose a contrastive learning framework that builds document embeddings for scholarly articles using citation graphs and textual metadata.",
+    "url": "https://arxiv.org/abs/2109.54321",
+    "published": "2021-09-30"
+  }
+]

--- a/backend/app/schemas/research.py
+++ b/backend/app/schemas/research.py
@@ -1,0 +1,33 @@
+"""Schemas for the research discovery API."""
+
+from pydantic import BaseModel, Field
+
+
+class ResearchQueryRequest(BaseModel):
+    """Request payload for discovering relevant research papers."""
+
+    query: str = Field(..., min_length=1, description="Description of the desired research paper")
+    max_results: int = Field(
+        default=3,
+        ge=1,
+        le=5,
+        description="Maximum number of ranked papers to return",
+    )
+
+
+class ResearchResultPayload(BaseModel):
+    """Single research result returned to the client UI."""
+
+    paper_id: str
+    title: str
+    summary: str
+    url: str
+    published: str | None = None
+    relevance: float
+    justification: str
+
+
+__all__ = [
+    "ResearchQueryRequest",
+    "ResearchResultPayload",
+]

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -2,6 +2,16 @@
 
 from .emotion import EmotionAnalyzer, EmotionTaxonomy
 from .note import AnnotationResult, NoteAnnotator, NoteAnnotationError
+from .research import (
+    ArxivPaper,
+    CandidateMatch,
+    ResearchDiscoveryService,
+    ResearchEvent,
+    ResearchResult,
+    ResearchResultsEvent,
+    ResearchServiceError,
+    ResearchStepEvent,
+)
 from .storage import AudioUploadResult, S3AudioStorage, StorageServiceError
 from .tutor import TutorModeService
 
@@ -11,6 +21,14 @@ __all__ = [
     "AnnotationResult",
     "NoteAnnotator",
     "NoteAnnotationError",
+    "ArxivPaper",
+    "CandidateMatch",
+    "ResearchDiscoveryService",
+    "ResearchEvent",
+    "ResearchResult",
+    "ResearchResultsEvent",
+    "ResearchServiceError",
+    "ResearchStepEvent",
     "AudioUploadResult",
     "S3AudioStorage",
     "StorageServiceError",

--- a/backend/app/services/research.py
+++ b/backend/app/services/research.py
@@ -1,0 +1,411 @@
+"""Research discovery service that performs RAG over an ArXiv corpus."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import AsyncIterator, Literal
+import json
+import math
+
+import httpx
+
+
+class ResearchServiceError(RuntimeError):
+    """Raised when the research discovery pipeline fails."""
+
+
+@dataclass(slots=True)
+class ArxivPaper:
+    """Metadata for a single ArXiv paper."""
+
+    paper_id: str
+    title: str
+    summary: str
+    url: str
+    published: str
+
+    def to_document(self) -> str:
+        """Return a formatted document string for scoring and LLM prompts."""
+
+        return f"{self.title}\n{self.summary}"
+
+
+@dataclass(slots=True)
+class CandidateMatch:
+    """A retrieval candidate with heuristic and rerank scores."""
+
+    paper: ArxivPaper
+    retrieval_score: float
+    rerank_score: float | None = None
+
+
+@dataclass(slots=True)
+class ResearchResult:
+    """A final research recommendation returned to the client."""
+
+    paper_id: str
+    title: str
+    summary: str
+    url: str
+    published: str
+    relevance: float
+    justification: str
+
+
+@dataclass(slots=True)
+class ResearchStepEvent:
+    """Represents progress for a pipeline step."""
+
+    type: Literal["step"]
+    step_id: str
+    status: Literal["started", "completed", "failed"]
+    message: str
+    payload: dict | None = None
+
+
+@dataclass(slots=True)
+class ResearchResultsEvent:
+    """Carries the final ranked results."""
+
+    type: Literal["results"]
+    results: list[ResearchResult]
+
+
+ResearchEvent = ResearchStepEvent | ResearchResultsEvent
+
+
+class ResearchDiscoveryService:
+    """Run a retrieval-augmented search workflow over a local ArXiv index."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str,
+        model: str,
+        cohere_api_key: str,
+        cohere_model: str,
+        index_path: str | Path,
+        max_context_chars: int = 1200,
+    ) -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._model = model
+        self._cohere_api_key = cohere_api_key
+        self._cohere_model = cohere_model
+        self._index_path = Path(index_path)
+        self._max_context_chars = max_context_chars
+        self._papers = self._load_index(self._index_path)
+
+    async def stream_search(
+        self, query: str, *, max_results: int = 3
+    ) -> AsyncIterator[ResearchEvent]:
+        """Stream pipeline events as the research workflow runs."""
+
+        if not query.strip():
+            raise ResearchServiceError("Query must not be empty")
+
+        yield ResearchStepEvent(
+            type="step",
+            step_id="expand",
+            status="started",
+            message="Expanding the research query with GPT-5",
+        )
+        expansions = await self._expand_query(query)
+        yield ResearchStepEvent(
+            type="step",
+            step_id="expand",
+            status="completed",
+            message="Generated expanded search intents",
+            payload={"expansions": expansions},
+        )
+
+        yield ResearchStepEvent(
+            type="step",
+            step_id="retrieve",
+            status="started",
+            message="Retrieving relevant ArXiv passages",
+        )
+        candidates = self._retrieve_candidates(query, expansions, limit=max_results * 4)
+        yield ResearchStepEvent(
+            type="step",
+            step_id="retrieve",
+            status="completed",
+            message=f"Retrieved {len(candidates)} candidate papers",
+            payload={
+                "candidates": [
+                    {
+                        "paper_id": match.paper.paper_id,
+                        "title": match.paper.title,
+                        "score": match.retrieval_score,
+                    }
+                    for match in candidates
+                ]
+            },
+        )
+
+        yield ResearchStepEvent(
+            type="step",
+            step_id="rank",
+            status="started",
+            message="Reranking candidates with Cohere",
+        )
+        ranked = await self._rerank_candidates(query, candidates)
+        yield ResearchStepEvent(
+            type="step",
+            step_id="rank",
+            status="completed",
+            message="Ranked candidates with semantic similarity",
+            payload={
+                "ranking": [
+                    {
+                        "paper_id": match.paper.paper_id,
+                        "score": match.rerank_score,
+                    }
+                    for match in ranked
+                ]
+            },
+        )
+
+        yield ResearchStepEvent(
+            type="step",
+            step_id="explain",
+            status="started",
+            message="Using GPT-5 to explain relevance",
+        )
+        final_results: list[ResearchResult] = []
+        for match in ranked[:max_results]:
+            justification = await self._explain_relevance(query, match.paper)
+            final_results.append(
+                ResearchResult(
+                    paper_id=match.paper.paper_id,
+                    title=match.paper.title,
+                    summary=match.paper.summary,
+                    url=match.paper.url,
+                    published=match.paper.published,
+                    relevance=match.rerank_score or 0.0,
+                    justification=justification,
+                )
+            )
+        yield ResearchStepEvent(
+            type="step",
+            step_id="explain",
+            status="completed",
+            message="Prepared relevance explanations",
+        )
+
+        yield ResearchResultsEvent(type="results", results=final_results)
+
+    def _load_index(self, path: Path) -> list[ArxivPaper]:
+        if not path.exists():
+            raise ResearchServiceError(
+                f"ArXiv index not found at {path}. Provide ARXIV_INDEX_PATH env variable."
+            )
+
+        try:
+            data = json.loads(path.read_text())
+        except json.JSONDecodeError as exc:  # pragma: no cover - invalid data
+            raise ResearchServiceError("ArXiv index file is not valid JSON") from exc
+
+        papers: list[ArxivPaper] = []
+        for item in data:
+            try:
+                papers.append(
+                    ArxivPaper(
+                        paper_id=item["paper_id"],
+                        title=item["title"],
+                        summary=item["summary"],
+                        url=item["url"],
+                        published=item.get("published", ""),
+                    )
+                )
+            except KeyError as exc:  # pragma: no cover - invalid data
+                raise ResearchServiceError(
+                    "ArXiv index entry is missing required fields"
+                ) from exc
+        if not papers:
+            raise ResearchServiceError("ArXiv index is empty")
+        return papers
+
+    async def _expand_query(self, query: str) -> list[str]:
+        system_prompt = (
+            "You are a research librarian assisting with academic literature searches. "
+            "Expand the user's query into three diverse search intents that include synonyms, "
+            "related methods, and adjacent application areas. Return each intent on a new line."
+        )
+        payload = {
+            "model": self._model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {
+                    "role": "user",
+                    "content": (
+                        "Original query:\n" + query.strip() + "\n\nExpanded search intents:"
+                    ),
+                },
+            ],
+            "temperature": 0.2,
+        }
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            try:
+                response = await client.post(
+                    f"{self._base_url}/chat/completions", json=payload, headers=headers
+                )
+                response.raise_for_status()
+            except httpx.HTTPError as exc:  # pragma: no cover - network errors
+                raise ResearchServiceError("Failed to expand query with GPT-5") from exc
+        data = response.json()
+        try:
+            content: str = data["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError) as exc:
+            raise ResearchServiceError("Unexpected response from GPT-5 query expansion") from exc
+
+        lines = [line.strip("- ") for line in content.splitlines() if line.strip()]
+        expansions = [line for line in lines if line]
+        if not expansions:
+            expansions = [query.strip()]
+        return expansions[:5]
+
+    def _retrieve_candidates(
+        self, query: str, expansions: list[str], *, limit: int
+    ) -> list[CandidateMatch]:
+        tokens_sets = [self._tokenize(query)] + [self._tokenize(item) for item in expansions]
+
+        candidates: list[CandidateMatch] = []
+        for paper in self._papers:
+            doc_tokens = self._tokenize(paper.to_document())
+            score = 0.0
+            for q_tokens in tokens_sets:
+                if not q_tokens:
+                    continue
+                overlap = len(doc_tokens & q_tokens)
+                score += overlap / math.sqrt(len(doc_tokens) * len(q_tokens)) if doc_tokens else 0.0
+            if score > 0:
+                candidates.append(CandidateMatch(paper=paper, retrieval_score=score))
+
+        candidates.sort(key=lambda match: match.retrieval_score, reverse=True)
+        return candidates[:limit]
+
+    async def _rerank_candidates(
+        self, query: str, candidates: list[CandidateMatch]
+    ) -> list[CandidateMatch]:
+        if not candidates:
+            return []
+
+        payload = {
+            "model": self._cohere_model,
+            "query": query,
+            "documents": [
+                {
+                    "id": match.paper.paper_id,
+                    "text": self._clip_document(match.paper.to_document()),
+                    "metadata": {
+                        "title": match.paper.title,
+                        "url": match.paper.url,
+                    },
+                }
+                for match in candidates
+            ],
+        }
+        headers = {
+            "Authorization": f"Bearer {self._cohere_api_key}",
+            "Content-Type": "application/json",
+        }
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            try:
+                response = await client.post(
+                    "https://api.cohere.com/v1/rerank", json=payload, headers=headers
+                )
+                response.raise_for_status()
+            except httpx.HTTPError as exc:  # pragma: no cover - network errors
+                raise ResearchServiceError("Failed to rerank candidates with Cohere") from exc
+
+        data = response.json()
+        try:
+            results = data["results"]
+        except (KeyError, TypeError) as exc:
+            raise ResearchServiceError("Unexpected response from Cohere rerank API") from exc
+
+        scores: dict[int, float] = {}
+        for entry in results:
+            try:
+                index = entry["index"]
+                score = float(entry.get("relevance_score", 0.0))
+            except (TypeError, KeyError, ValueError) as exc:
+                raise ResearchServiceError(
+                    "Cohere rerank response contained invalid entries"
+                ) from exc
+            scores[index] = score
+
+        for idx, match in enumerate(candidates):
+            match.rerank_score = scores.get(idx, 0.0)
+
+        candidates.sort(key=lambda match: match.rerank_score or 0.0, reverse=True)
+        return candidates
+
+    async def _explain_relevance(self, query: str, paper: ArxivPaper) -> str:
+        system_prompt = (
+            "You are a research assistant. Explain in two sentences why the following ArXiv paper "
+            "is relevant to the user's query. Reference specific concepts from the summary."
+        )
+        payload = {
+            "model": self._model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {
+                    "role": "user",
+                    "content": (
+                        "User query: "
+                        + query.strip()
+                        + "\n\nPaper title: "
+                        + paper.title
+                        + "\nSummary: "
+                        + paper.summary
+                    ),
+                },
+            ],
+            "temperature": 0.4,
+        }
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            try:
+                response = await client.post(
+                    f"{self._base_url}/chat/completions", json=payload, headers=headers
+                )
+                response.raise_for_status()
+            except httpx.HTTPError as exc:  # pragma: no cover - network errors
+                raise ResearchServiceError("Failed to explain relevance with GPT-5") from exc
+        data = response.json()
+        try:
+            return data["choices"][0]["message"]["content"].strip()
+        except (KeyError, IndexError, TypeError) as exc:
+            raise ResearchServiceError("Unexpected response from GPT-5 relevance explainer") from exc
+
+    def _clip_document(self, document: str) -> str:
+        if len(document) <= self._max_context_chars:
+            return document
+        return document[: self._max_context_chars] + "…"
+
+    def _tokenize(self, text: str) -> set[str]:
+        cleaned = "".join(ch.lower() if ch.isalnum() else " " for ch in text)
+        return {token for token in cleaned.split() if token}
+
+
+__all__ = [
+    "ArxivPaper",
+    "CandidateMatch",
+    "ResearchDiscoveryService",
+    "ResearchEvent",
+    "ResearchResult",
+    "ResearchResultsEvent",
+    "ResearchServiceError",
+    "ResearchStepEvent",
+]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,23 @@
+import sys
+import types
+
+import pytest
+
+
+class _StubS3Client:
+    def put_object(self, **_: object) -> None:  # pragma: no cover - stub behavior
+        return None
+
+
+def _stub_client(service_name: str, **_: object):  # pragma: no cover - stub behavior
+    if service_name != "s3":
+        raise ValueError(f"Unsupported service {service_name}")
+    return _StubS3Client()
+
+
+boto3_stub = types.SimpleNamespace(client=_stub_client)
+sys.modules.setdefault("boto3", boto3_stub)
+
+
+def pytest_configure(config: pytest.Config) -> None:  # pragma: no cover - pytest hook
+    config.addinivalue_line("markers", "asyncio: mark async tests")

--- a/backend/tests/test_research_route.py
+++ b/backend/tests/test_research_route.py
@@ -1,0 +1,65 @@
+from fastapi.testclient import TestClient
+
+from app.api.dependencies import get_research_service
+from app.main import app
+from app.services.research import (
+    ResearchResult,
+    ResearchResultsEvent,
+    ResearchStepEvent,
+)
+
+
+class StubResearchService:
+    async def stream_search(self, query: str, max_results: int):
+        yield ResearchStepEvent(
+            type="step",
+            step_id="expand",
+            status="started",
+            message="Expanding query",
+            payload={"expansions": ["test expansion"]},
+        )
+        yield ResearchStepEvent(
+            type="step",
+            step_id="expand",
+            status="completed",
+            message="Expansion complete",
+            payload={"expansions": ["test expansion"]},
+        )
+        yield ResearchResultsEvent(
+            type="results",
+            results=[
+                ResearchResult(
+                    paper_id="1234.56789",
+                    title="Example Paper",
+                    summary="Summary",
+                    url="https://arxiv.org/abs/1234.56789",
+                    published="2024-01-01",
+                    relevance=0.95,
+                    justification="Because it matches your query.",
+                )
+            ],
+        )
+
+
+def test_research_route_streams_events():
+    original = app.dependency_overrides.get(get_research_service)
+    app.dependency_overrides[get_research_service] = lambda: StubResearchService()
+
+    try:
+        with TestClient(app) as client:
+            with client.stream(
+                "POST",
+                "/api/v1/research/discover",
+                json={"query": "test", "max_results": 1},
+            ) as response:
+                body = "".join(response.iter_text())
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+        assert "expanding query" in body.lower()
+        assert "example paper" in body.lower()
+    finally:
+        if original is not None:
+            app.dependency_overrides[get_research_service] = original
+        else:
+            app.dependency_overrides.pop(get_research_service, None)

--- a/backend/tests/test_research_service.py
+++ b/backend/tests/test_research_service.py
@@ -1,0 +1,125 @@
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from app.services.research import (
+    ResearchDiscoveryService,
+    ResearchResultsEvent,
+    ResearchStepEvent,
+)
+
+
+class FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:  # pragma: no cover - no-op
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class FakeAsyncClient:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - fixture use
+        self._args = args
+        self._kwargs = kwargs
+
+    async def __aenter__(self) -> "FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:  # pragma: no cover - fixture use
+        return None
+
+    async def post(self, url: str, json: dict[str, Any], headers: dict[str, str]):
+        if url.endswith("/chat/completions"):
+            user_message = json["messages"][1]["content"]
+            if "Expanded search intents" in user_message:
+                payload = {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": "quantum advantage benchmarking\nnoise-aware algorithms\nerror-mitigated variational solvers",
+                            }
+                        }
+                    ]
+                }
+            else:
+                title_line = user_message.split("Paper title: ")[-1].split("\n")[0]
+                payload = {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": f"{title_line} is relevant because it advances quantum advantage research.",
+                            }
+                        }
+                    ]
+                }
+            return FakeResponse(payload)
+        if "cohere.com" in url:
+            documents = json["documents"]
+            payload = {
+                "results": [
+                    {"index": idx, "relevance_score": 1.0 - idx * 0.1}
+                    for idx, _ in enumerate(documents)
+                ]
+            }
+            return FakeResponse(payload)
+        raise AssertionError(f"Unexpected URL {url}")
+
+
+def test_stream_search_produces_ranked_results(monkeypatch, tmp_path):
+    import asyncio
+
+    index_path = tmp_path / "arxiv.json"
+    index_path.write_text(
+        json.dumps(
+            [
+                {
+                    "paper_id": "2007.09876",
+                    "title": "Quantum Advantage in Noisy Intermediate-Scale Quantum Devices",
+                    "summary": "Survey of algorithms demonstrating quantum advantage with mitigation techniques.",
+                    "url": "https://arxiv.org/abs/2007.09876",
+                    "published": "2020-07-20",
+                },
+                {
+                    "paper_id": "2301.00001",
+                    "title": "Scaling Instruction-Following with Large Language Models",
+                    "summary": "Alignment strategies for large models.",
+                    "url": "https://arxiv.org/abs/2301.00001",
+                    "published": "2023-01-01",
+                },
+            ]
+        )
+    )
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+    service = ResearchDiscoveryService(
+        api_key="test-key",
+        base_url="https://api.openai.com/v1",
+        model="gpt-5.0",
+        cohere_api_key="cohere-key",
+        cohere_model="rerank-test",
+        index_path=index_path,
+    )
+
+    async def _collect() -> list[object]:
+        events: list[object] = []
+        async for event in service.stream_search("quantum advantage techniques", max_results=1):
+            events.append(event)
+        return events
+
+    events = asyncio.run(_collect())
+
+    assert isinstance(events[0], ResearchStepEvent)
+    assert events[0].step_id == "expand"
+    assert isinstance(events[-1], ResearchResultsEvent)
+    final_event = events[-1]
+    assert len(final_event.results) == 1
+    top_result = final_event.results[0]
+    assert top_result.paper_id == "2007.09876"
+    assert "quantum advantage" in top_result.justification.lower()

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -9,6 +9,7 @@ import {
   MessageCircle,
   Brain,
   NotebookPen,
+  Search,
 } from "lucide-react";
 
 const featureCards = [
@@ -38,6 +39,15 @@ const featureCards = [
     icon: MessageCircle,
     accent: "from-emerald-400/80 to-teal-500/80",
     pill: "Guided Actions",
+  },
+  {
+    name: "Research Discovery",
+    description:
+      "Stream GPT-5 reasoning as it expands your query, searches ArXiv, reranks with Cohere, and justifies the picks.",
+    href: "/research-discovery",
+    icon: Search,
+    accent: "from-emerald-400/80 to-lime-500/80",
+    pill: "RAG Search",
   },
   {
     name: "Notes Workspace",

--- a/frontend/app/research-discovery/page.tsx
+++ b/frontend/app/research-discovery/page.tsx
@@ -1,0 +1,512 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { BookOpenCheck, Bot, Search, Sparkles, Undo2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
+
+type StepStatus = "pending" | "running" | "complete" | "error";
+
+type Step = {
+  id: string;
+  label: string;
+  status: StepStatus;
+  message?: string;
+  payload?: unknown;
+};
+
+type StreamStepEvent = {
+  type: "step";
+  step_id: string;
+  status: "started" | "completed" | "failed";
+  message: string;
+  payload?: Record<string, unknown> | null;
+};
+
+type StreamResultsEvent = {
+  type: "results";
+  results: ResearchResult[];
+};
+
+type StreamErrorEvent = {
+  type: "error";
+  message: string;
+};
+
+type StreamEvent = StreamStepEvent | StreamResultsEvent | StreamErrorEvent;
+
+type ResearchResult = {
+  paper_id: string;
+  title: string;
+  summary: string;
+  url: string;
+  published?: string | null;
+  relevance: number;
+  justification: string;
+};
+
+type LogEntry = {
+  id: string;
+  status: StepStatus;
+  title: string;
+  detail?: string;
+  payload?: unknown;
+};
+
+const createDefaultSteps = (): Step[] => [
+  { id: "expand", label: "Expand with GPT-5", status: "pending" },
+  { id: "retrieve", label: "Retrieve from ArXiv", status: "pending" },
+  { id: "rank", label: "Rank with Cohere", status: "pending" },
+  { id: "explain", label: "Explain relevance", status: "pending" },
+];
+
+const statusIconClasses: Record<StepStatus, string> = {
+  pending: "border-slate-700 text-slate-500",
+  running: "border-emerald-400/60 text-emerald-300 animate-pulse",
+  complete: "border-emerald-400/60 text-emerald-200",
+  error: "border-rose-500/60 text-rose-300",
+};
+
+const statusDotClasses: Record<StepStatus, string> = {
+  pending: "bg-slate-700",
+  running: "bg-emerald-400 animate-ping",
+  complete: "bg-emerald-400",
+  error: "bg-rose-500",
+};
+
+const statusLabel: Record<StepStatus, string> = {
+  pending: "Waiting",
+  running: "Running",
+  complete: "Complete",
+  error: "Error",
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+};
+
+const parseEventPayload = (chunk: string): StreamEvent | null => {
+  const lines = chunk
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("data:"));
+  if (lines.length === 0) return null;
+  const payload = lines.map((line) => line.slice(5).trim()).join("\n");
+  if (!payload) return null;
+  try {
+    return JSON.parse(payload) as StreamEvent;
+  } catch (error) {
+    console.error("Failed to parse stream payload", error, payload);
+    return { type: "error", message: "Received an unreadable update from the server." };
+  }
+};
+
+const mapStepStatus = (status: StreamStepEvent["status"]): StepStatus => {
+  if (status === "started") return "running";
+  if (status === "completed") return "complete";
+  return "error";
+};
+
+const formatScore = (score: number): string => `${(score * 100).toFixed(0)}%`;
+
+export default function ResearchDiscoveryPage(): JSX.Element {
+  const [query, setQuery] = useState("");
+  const [maxResults, setMaxResults] = useState(3);
+  const [steps, setSteps] = useState<Step[]>(createDefaultSteps);
+  const [logEntries, setLogEntries] = useState<LogEntry[]>([]);
+  const [results, setResults] = useState<ResearchResult[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const controllerRef = useRef<AbortController | null>(null);
+
+  const resetWorkflow = useCallback(() => {
+    setSteps(createDefaultSteps());
+    setLogEntries([]);
+    setResults([]);
+    setError(null);
+  }, []);
+
+  const handleStreamEvent = useCallback((event: StreamEvent) => {
+    if (event.type === "step") {
+      setSteps((previous) =>
+        previous.map((step) =>
+          step.id === event.step_id
+            ? {
+                ...step,
+                status: mapStepStatus(event.status),
+                message: event.message,
+                payload: event.payload ?? undefined,
+              }
+            : step
+        )
+      );
+
+      setLogEntries((previous) => [
+        ...previous,
+        {
+          id: `${event.step_id}-${event.status}-${previous.length}`,
+          status: mapStepStatus(event.status),
+          title: event.message,
+          payload: event.payload ?? undefined,
+          detail:
+            event.status === "completed" && event.payload
+              ? JSON.stringify(event.payload)
+              : undefined,
+        },
+      ]);
+    } else if (event.type === "results") {
+      setResults(event.results);
+      setLogEntries((previous) => [
+        ...previous,
+        {
+          id: `results-${previous.length}`,
+          status: "complete",
+          title: "Delivered ranked research papers.",
+        },
+      ]);
+    } else if (event.type === "error") {
+      setError(event.message);
+      setSteps((previous) =>
+        previous.map((step) =>
+          step.status === "running"
+            ? { ...step, status: "error", message: event.message }
+            : step
+        )
+      );
+      setLogEntries((previous) => [
+        ...previous,
+        {
+          id: `error-${previous.length}`,
+          status: "error",
+          title: event.message,
+        },
+      ]);
+    }
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!query.trim() || isStreaming) return;
+
+      controllerRef.current?.abort();
+      resetWorkflow();
+      const controller = new AbortController();
+      controllerRef.current = controller;
+      setIsStreaming(true);
+
+      try {
+        const response = await fetch(`${API_BASE}/research/discover`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ query: query.trim(), max_results: maxResults }),
+          signal: controller.signal,
+        });
+
+        if (!response.ok || !response.body) {
+          const message = await response.text();
+          throw new Error(
+            message || "The research service could not start streaming results."
+          );
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+
+          let boundary = buffer.indexOf("\n\n");
+          while (boundary !== -1) {
+            const chunk = buffer.slice(0, boundary).trim();
+            buffer = buffer.slice(boundary + 2);
+            if (chunk) {
+              const eventPayload = parseEventPayload(chunk);
+              if (eventPayload) {
+                handleStreamEvent(eventPayload);
+              }
+            }
+            boundary = buffer.indexOf("\n\n");
+          }
+        }
+      } catch (err) {
+        if ((err as Error).name === "AbortError") {
+          setError("Streaming cancelled.");
+        } else {
+          console.error(err);
+          setError(
+            err instanceof Error
+              ? err.message
+              : "Unable to reach the research discovery service."
+          );
+          setSteps((previous) =>
+            previous.map((step) =>
+              step.status === "running"
+                ? { ...step, status: "error", message: "Request aborted." }
+                : step
+            )
+          );
+        }
+      } finally {
+        setIsStreaming(false);
+        controllerRef.current = null;
+      }
+    },
+    [handleStreamEvent, isStreaming, maxResults, query, resetWorkflow]
+  );
+
+  const handleAbort = useCallback(() => {
+    if (controllerRef.current) {
+      controllerRef.current.abort();
+    }
+  }, []);
+
+  const isSubmitDisabled = useMemo(
+    () => query.trim().length === 0 || isStreaming,
+    [isStreaming, query]
+  );
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <header className="border-b border-slate-800 bg-slate-900/70 backdrop-blur">
+        <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+          <div className="flex items-center gap-3">
+            <div className="rounded-xl border border-emerald-400/40 bg-emerald-400/10 p-2">
+              <BookOpenCheck className="h-6 w-6 text-emerald-300" />
+            </div>
+            <div>
+              <h1 className="text-xl font-semibold">ArXiv Research Discovery</h1>
+              <p className="text-sm text-slate-400">
+                Describe the paper you need and watch the RAG workflow unfold live.
+              </p>
+            </div>
+          </div>
+          <nav className="text-sm text-slate-400">
+            <Link href="/" className="hover:text-slate-100">
+              Home
+            </Link>
+            <span className="mx-2 text-slate-700">/</span>
+            <span className="text-slate-100">Research discovery</span>
+          </nav>
+        </div>
+      </header>
+
+      <main className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-6 py-10">
+        <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-xl">
+          <form className="space-y-6" onSubmit={handleSubmit}>
+            <div>
+              <label className="text-sm font-medium text-slate-200" htmlFor="query">
+                Describe your target paper
+              </label>
+              <textarea
+                id="query"
+                name="query"
+                rows={5}
+                required
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Example: I'm looking for a recent RAG paper that evaluates retrieval quality for enterprise knowledge bases"
+                className="mt-2 w-full rounded-lg border border-slate-700 bg-slate-950/70 px-3 py-2 text-sm leading-6 text-slate-100 outline-none transition focus:border-emerald-400 focus:ring-2 focus:ring-emerald-500/40"
+              />
+            </div>
+
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-center gap-3 text-sm text-slate-300">
+                <Bot className="h-5 w-5 text-emerald-300" />
+                <span>
+                  GPT-5 expands your query, searches our ArXiv cache, reranks with Cohere, and
+                  justifies every recommendation.
+                </span>
+              </div>
+              <div className="flex items-center gap-3 text-sm">
+                <label htmlFor="maxResults" className="text-slate-300">
+                  Top results
+                </label>
+                <input
+                  id="maxResults"
+                  name="maxResults"
+                  type="number"
+                  min={1}
+                  max={5}
+                  value={maxResults}
+                  onChange={(event) => setMaxResults(Number(event.target.value))}
+                  className="h-10 w-16 rounded-md border border-slate-700 bg-slate-950 px-2 text-center text-sm text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                />
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <Button
+                type="submit"
+                className="bg-emerald-400 text-slate-950 hover:bg-emerald-300"
+                disabled={isSubmitDisabled}
+              >
+                <Sparkles className="mr-2 h-4 w-4" /> Start discovery
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleAbort}
+                disabled={!isStreaming}
+                className="border-slate-700 bg-slate-950/60 text-slate-200 hover:bg-slate-900/70 disabled:cursor-not-allowed disabled:border-slate-800 disabled:text-slate-600"
+              >
+                <Undo2 className="mr-2 h-4 w-4" /> Cancel stream
+              </Button>
+            </div>
+
+            {error && (
+              <div className="rounded-lg border border-rose-500/50 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+                {error}
+              </div>
+            )}
+          </form>
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+          <div className="space-y-4 rounded-2xl border border-slate-800 bg-slate-900/60 p-5">
+            <div className="flex items-center gap-3">
+              <Search className="h-5 w-5 text-emerald-300" />
+              <h2 className="text-lg font-semibold">Live reasoning trace</h2>
+            </div>
+            <ul className="space-y-4">
+              {steps.map((step) => (
+                <li
+                  key={step.id}
+                  className={`rounded-xl border px-4 py-3 transition ${statusIconClasses[step.status]}`}
+                >
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="font-medium text-slate-100">{step.label}</span>
+                    <span className="flex items-center gap-2 text-xs uppercase tracking-wide text-slate-400">
+                      <span
+                        className={`h-2.5 w-2.5 rounded-full ${statusDotClasses[step.status]}`}
+                      />
+                      {statusLabel[step.status]}
+                    </span>
+                  </div>
+                  {step.message && (
+                    <p className="mt-2 text-sm text-slate-300">{step.message}</p>
+                  )}
+                  {step.id === "expand" && isRecord(step.payload) && Array.isArray(step.payload.expansions) && (
+                    <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-300">
+                      {(step.payload.expansions as string[]).map((item) => (
+                        <span
+                          key={item}
+                          className="rounded-full border border-emerald-400/40 bg-emerald-400/10 px-3 py-1"
+                        >
+                          {item}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  {step.id === "rank" && isRecord(step.payload) && Array.isArray(step.payload.ranking) && (
+                    <div className="mt-3 space-y-2 text-xs text-slate-400">
+                      {(step.payload.ranking as { paper_id: string; score: number | null }[])
+                        .slice(0, 3)
+                        .map((entry) => (
+                          <div
+                            key={entry.paper_id}
+                            className="flex items-center justify-between rounded-lg border border-slate-800 bg-slate-950/60 px-3 py-2"
+                          >
+                            <span className="font-mono text-[11px] text-slate-400">
+                              {entry.paper_id}
+                            </span>
+                            <span className="text-emerald-300">
+                              {formatScore(entry.score ?? 0)}
+                            </span>
+                          </div>
+                        ))}
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="space-y-4 rounded-2xl border border-slate-800 bg-slate-900/60 p-5">
+            <div className="flex items-center gap-3">
+              <Sparkles className="h-5 w-5 text-emerald-300" />
+              <h2 className="text-lg font-semibold">Execution log</h2>
+            </div>
+            <div className="space-y-3">
+              {logEntries.length === 0 && (
+                <p className="text-sm text-slate-500">
+                  Submit a description to watch GPT-5 narrate each action it takes.
+                </p>
+              )}
+              {logEntries.map((entry) => (
+                <div
+                  key={entry.id}
+                  className="rounded-xl border border-slate-800 bg-slate-950/60 px-4 py-3 text-sm text-slate-300"
+                >
+                  <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-500">
+                    <span>{statusLabel[entry.status]}</span>
+                    <span>{entry.status === "complete" ? "✓" : "…"}</span>
+                  </div>
+                  <p className="mt-1 text-sm text-slate-200">{entry.title}</p>
+                  {entry.payload && typeof entry.payload === "object" && entry.payload !== null && (
+                    <pre className="mt-2 max-h-40 overflow-y-auto rounded-lg bg-slate-950/80 p-3 text-xs text-slate-400">
+                      {JSON.stringify(entry.payload, null, 2)}
+                    </pre>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <div className="flex items-center gap-3">
+            <BookOpenCheck className="h-5 w-5 text-emerald-300" />
+            <h2 className="text-lg font-semibold">Top matches</h2>
+          </div>
+          {results.length === 0 ? (
+            <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-8 text-center text-sm text-slate-400">
+              When the pipeline finishes, the most relevant ArXiv papers will surface here with GPT-5 justifications.
+            </div>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2">
+              {results.map((result) => (
+                <article
+                  key={result.paper_id}
+                  className="group flex flex-col gap-3 rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-xl transition hover:border-emerald-400/60 hover:shadow-emerald-500/10"
+                >
+                  <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-500">
+                    <span className="font-mono text-emerald-300">{result.paper_id}</span>
+                    <span className="rounded-full border border-emerald-400/40 bg-emerald-400/10 px-2 py-1 text-emerald-200">
+                      {formatScore(result.relevance)} relevant
+                    </span>
+                  </div>
+                  <h3 className="text-lg font-semibold text-slate-100">{result.title}</h3>
+                  {result.published && (
+                    <p className="text-xs text-slate-500">Published: {result.published}</p>
+                  )}
+                  <p className="text-sm leading-6 text-slate-300">{result.summary}</p>
+                  <div className="rounded-xl border border-slate-800 bg-slate-950/80 p-4 text-sm text-slate-200">
+                    <strong className="text-emerald-300">Why it matters:</strong>
+                    <p className="mt-2 text-slate-300">{result.justification}</p>
+                  </div>
+                  <Button
+                    asChild
+                    variant="outline"
+                    className="border-emerald-400/50 bg-transparent text-emerald-200 hover:bg-emerald-400/10"
+                  >
+                    <Link href={result.url} target="_blank" rel="noreferrer">
+                      View on arXiv
+                    </Link>
+                  </Button>
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a research discovery service that expands queries with GPT-5, performs local ArXiv retrieval, reranks with Cohere, and streams SSE responses
- expose supporting schemas, configuration, sample index data, and tests including boto3 stubs and streaming API coverage
- create a research discovery Next.js page that streams reasoning steps, shows ranked results, and link it from the landing page

## Testing
- PYTHONPATH=. poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d83800c5988327bb827a9a0631d46b