### PR TITLE
Tweak landing page brand text styling

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -153,8 +153,8 @@ export default function LandingPage(): JSX.Element {
               />
             </div>
             <div className="flex flex-col">
-              <span className="text-xs uppercase tracking-[0.45em] text-amber-200/90">
-                A Glowing Star
+              <span className="text-xs font-medium tracking-[0.3em] text-amber-200/90">
+                Glowingstar.ai
               </span>
               <span className="text-xl font-semibold text-slate-50">
                 Experience Studio


### PR DESCRIPTION
## Summary
- soften the Experience Studio hero brand label by switching the text to standard casing and easing the letter spacing for readability

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d83dcd842c83278fc1f847ef8c5365