### PR TITLE
Add streamed research discovery pipeline and UI

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -8,6 +8,7 @@ from app.services.emotion import EmotionAnalyzer
 from app.services.note import NoteAnnotator
 from app.services.payment import StripePaymentService
 from app.services.realtime import RealtimeSessionClient
+from app.services.research import ResearchDiscoveryService
 from app.services.storage import S3AudioStorage, StorageServiceError
 from app.services.tutor import TutorModeService
 
@@ -74,6 +75,35 @@ def get_note_annotator() -> NoteAnnotator:
         base_url=settings.openai_api_base_url,
         model=settings.openai_annotation_model,
     )
+
+
+@lru_cache
+def _get_research_service() -> ResearchDiscoveryService:
+    settings = _get_settings()
+    if not settings.openai_api_key:
+        raise ValueError("OpenAI API key is not configured for research discovery")
+    if not settings.cohere_api_key:
+        raise ValueError("Cohere API key is not configured for research discovery")
+
+    return ResearchDiscoveryService(
+        openai_api_key=settings.openai_api_key,
+        openai_base_url=settings.openai_api_base_url,
+        openai_model=settings.openai_research_model,
+        cohere_api_key=settings.cohere_api_key,
+        cohere_base_url=settings.cohere_api_base_url,
+        cohere_model=settings.cohere_rerank_model,
+        arxiv_api_url=settings.arxiv_api_base_url,
+        arxiv_max_results=settings.arxiv_max_results,
+    )
+
+
+def get_research_service() -> ResearchDiscoveryService:
+    """FastAPI dependency that provides the research discovery orchestrator."""
+
+    try:
+        return _get_research_service()
+    except ValueError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
 
 
 @lru_cache

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,9 +1,11 @@
 import base64
 import binascii
+import json
 from datetime import datetime, timezone
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
+from fastapi.responses import StreamingResponse
 from pydantic import HttpUrl
 
 from app.api.dependencies import (
@@ -13,6 +15,7 @@ from app.api.dependencies import (
     get_note_annotator,
     get_payment_service,
     get_realtime_client,
+    get_research_service,
     get_settings,
     get_tutor_service,
 )
@@ -31,6 +34,7 @@ from app.schemas.realtime import (
     VisionFrameRequest,
     VisionFrameResponse,
 )
+from app.schemas.research import ResearchPaperSummary, ResearchSearchRequest
 from app.schemas.note import NoteCreateRequest, NoteCreateResponse
 from app.schemas.tutor import TutorModeRequest, TutorModeResponse
 from app.services.auth import Auth0Client, Auth0ClientError
@@ -38,6 +42,7 @@ from app.services.emotion import EmotionAnalyzer
 from app.services.note import NoteAnnotator, NoteAnnotationError
 from app.services.payment import StripePaymentError, StripePaymentService
 from app.services.realtime import RealtimeSessionClient, RealtimeSessionError
+from app.services.research import ResearchDiscoveryService
 from app.services.storage import S3AudioStorage, StorageServiceError
 from app.services.tutor import TutorModeService
 
@@ -257,3 +262,125 @@ async def create_tutor_mode_plan(
     """Create a BabyAGI-inspired tutoring plan powered by GPT-5."""
 
     return await tutor_service.generate_plan(payload)
+
+
+def _encode_event(payload: dict[str, object]) -> str:
+    """Return a JSONL-safe representation of a streaming event."""
+
+    return json.dumps(payload, separators=(",", ":")) + "\n"
+
+
+@router.post(
+    "/research/discover",
+    response_model=None,
+    tags=["research"],
+    summary="Discover relevant arXiv papers with a streamed RAG workflow",
+)
+async def discover_research_papers(
+    payload: ResearchSearchRequest,
+    service: ResearchDiscoveryService = Depends(get_research_service),
+) -> StreamingResponse:
+    """Stream the reasoning trail for a research discovery request."""
+
+    top_k = payload.top_k or 5
+
+    async def event_stream():
+        try:
+            yield _encode_event(
+                {
+                    "type": "status",
+                    "stage": "expanding_query",
+                    "message": "Expanding your description with GPT-5",
+                }
+            )
+            expansions = await service.expand_query(payload.query)
+            yield _encode_event(
+                {
+                    "type": "expansion",
+                    "stage": "expanding_query",
+                    "message": "Generated expanded search intents",
+                    "expansions": expansions,
+                }
+            )
+
+            yield _encode_event(
+                {
+                    "type": "status",
+                    "stage": "retrieving_candidates",
+                    "message": "Querying arXiv for candidate papers",
+                }
+            )
+            candidates = await service.retrieve_papers(expansions)
+            yield _encode_event(
+                {
+                    "type": "retrieval",
+                    "stage": "retrieving_candidates",
+                    "message": f"Retrieved {len(candidates)} unique arXiv candidates",
+                    "count": len(candidates),
+                }
+            )
+
+            yield _encode_event(
+                {
+                    "type": "status",
+                    "stage": "ranking",
+                    "message": "Ranking candidates with Cohere's re-ranker",
+                }
+            )
+            ranked = await service.rank_papers(
+                query=payload.query, papers=candidates, top_k=top_k
+            )
+            ranked_summaries = [
+                paper.to_summary(score=score).model_dump(mode="json")
+                for paper, score in ranked
+            ]
+            yield _encode_event(
+                {
+                    "type": "ranking",
+                    "stage": "ranking",
+                    "message": "Identified the strongest matches",
+                    "total_candidates": len(candidates),
+                    "results": ranked_summaries,
+                }
+            )
+
+            enriched: list[ResearchPaperSummary] = []
+            for paper, score in ranked:
+                yield _encode_event(
+                    {
+                        "type": "status",
+                        "stage": "explaining",
+                        "message": f"Explaining relevance for {paper.title}",
+                        "paper_id": paper.paper_id,
+                    }
+                )
+                reason = await service.explain_relevance(query=payload.query, paper=paper)
+                summary = paper.to_summary(score=score, reason=reason)
+                enriched.append(summary)
+                yield _encode_event(
+                    {
+                        "type": "explanation",
+                        "stage": "explaining",
+                        "paper_id": paper.paper_id,
+                        "reason": reason,
+                    }
+                )
+
+            yield _encode_event(
+                {
+                    "type": "results",
+                    "stage": "complete",
+                    "message": "Finished building the research digest",
+                    "results": [item.model_dump(mode="json") for item in enriched],
+                }
+            )
+        except Exception as exc:  # pragma: no cover - defensive streaming guard
+            yield _encode_event(
+                {
+                    "type": "error",
+                    "stage": "error",
+                    "message": str(exc),
+                }
+            )
+
+    return StreamingResponse(event_stream(), media_type="application/jsonl")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -23,6 +23,9 @@ class Settings(BaseSettings):
     openai_annotation_model: str = Field(
         default="gpt-5.0", alias="OPENAI_ANNOTATION_MODEL"
     )
+    openai_research_model: str = Field(
+        default="gpt-5.0", alias="OPENAI_RESEARCH_MODEL"
+    )
     aws_access_key_id: str | None = Field(default=None, alias="AWS_ACCESS_KEY_ID")
     aws_secret_access_key: str | None = Field(
         default=None, alias="AWS_SECRET_ACCESS_KEY"
@@ -40,6 +43,17 @@ class Settings(BaseSettings):
         default=None, alias="STRIPE_DEFAULT_PRICE_ID"
     )
     stripe_mode: str = Field(default="subscription", alias="STRIPE_MODE")
+    cohere_api_key: str | None = Field(default=None, alias="COHERE_API_KEY")
+    cohere_api_base_url: str = Field(
+        default="https://api.cohere.com", alias="COHERE_API_BASE_URL"
+    )
+    cohere_rerank_model: str = Field(
+        default="rerank-english-v3.0", alias="COHERE_RERANK_MODEL"
+    )
+    arxiv_api_base_url: str = Field(
+        default="http://export.arxiv.org/api/query", alias="ARXIV_API_BASE_URL"
+    )
+    arxiv_max_results: int = Field(default=25, alias="ARXIV_MAX_RESULTS")
 
     model_config = {
         "env_file": ".env",

--- a/backend/app/schemas/research.py
+++ b/backend/app/schemas/research.py
@@ -1,0 +1,33 @@
+"""Schemas for the research discovery endpoint."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class ResearchSearchRequest(BaseModel):
+    """Payload accepted by the research discovery route."""
+
+    query: str = Field(..., min_length=3, description="Free-form description of the desired paper")
+    top_k: int | None = Field(
+        default=5,
+        ge=1,
+        le=10,
+        description="Maximum number of ranked results to return",
+    )
+
+
+class ResearchPaperSummary(BaseModel):
+    """Basic information about an arXiv paper."""
+
+    paper_id: str = Field(..., description="Canonical arXiv identifier")
+    title: str
+    summary: str
+    url: str
+    published_at: datetime | None = Field(default=None, description="Publication timestamp")
+    authors: list[str] = Field(default_factory=list)
+    score: float | None = Field(default=None, description="Relevance score from re-ranking")
+    reason: str | None = Field(
+        default=None,
+        description="Why the paper is relevant to the search query",
+    )

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -4,6 +4,7 @@ from .auth import Auth0Client, Auth0ClientError, AuthTokens, AuthUserInfo
 from .emotion import EmotionAnalyzer, EmotionTaxonomy
 from .note import AnnotationResult, NoteAnnotator, NoteAnnotationError
 from .payment import CheckoutSession, StripePaymentError, StripePaymentService
+from .research import ResearchDiscoveryService
 from .storage import AudioUploadResult, S3AudioStorage, StorageServiceError
 from .tutor import TutorModeService
 
@@ -24,4 +25,5 @@ __all__ = [
     "S3AudioStorage",
     "StorageServiceError",
     "TutorModeService",
+    "ResearchDiscoveryService",
 ]

--- a/backend/app/services/research.py
+++ b/backend/app/services/research.py
@@ -1,0 +1,344 @@
+"""Research discovery service orchestrating query expansion, retrieval, and ranking."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from xml.etree import ElementTree
+
+import httpx
+
+from app.schemas.research import ResearchPaperSummary
+
+
+@dataclass(slots=True)
+class ArxivPaper:
+    """Internal representation of an arXiv entry."""
+
+    paper_id: str
+    title: str
+    summary: str
+    url: str
+    published_at: datetime | None
+    authors: list[str]
+
+    def to_summary(self, *, score: float | None = None, reason: str | None = None) -> ResearchPaperSummary:
+        """Convert the internal paper to an API schema."""
+
+        return ResearchPaperSummary(
+            paper_id=self.paper_id,
+            title=self.title,
+            summary=self.summary,
+            url=self.url,
+            published_at=self.published_at,
+            authors=self.authors,
+            score=score,
+            reason=reason,
+        )
+
+
+class ResearchDiscoveryService:
+    """Coordinate a lightweight RAG flow across OpenAI, arXiv, and Cohere."""
+
+    def __init__(
+        self,
+        *,
+        openai_api_key: str | None,
+        openai_base_url: str,
+        openai_model: str,
+        cohere_api_key: str | None,
+        cohere_base_url: str,
+        cohere_model: str,
+        arxiv_api_url: str,
+        arxiv_max_results: int = 25,
+        timeout: float = 30.0,
+    ) -> None:
+        self.openai_api_key = openai_api_key
+        self.openai_base_url = openai_base_url.rstrip("/")
+        self.openai_model = openai_model
+        self.cohere_api_key = cohere_api_key
+        self.cohere_base_url = cohere_base_url.rstrip("/")
+        self.cohere_model = cohere_model
+        self.arxiv_api_url = arxiv_api_url
+        self.arxiv_max_results = arxiv_max_results
+        self.timeout = timeout
+
+    async def expand_query(self, query: str) -> list[str]:
+        """Use GPT-5 to expand the user's query into related search intents."""
+
+        if not self.openai_api_key:
+            raise RuntimeError("OpenAI API key is not configured")
+
+        prompt = (
+            "You are a research assistant helping a user search arXiv. "
+            "Generate 3 to 5 alternative phrasings or related keywords that "
+            "would be useful when searching for papers about the following description. "
+            "Return a JSON object with an 'expansions' field containing the list of strings.\n\n"
+            f"Description: {query}"
+        )
+        body: dict[str, Any] = {
+            "model": self.openai_model,
+            "input": prompt,
+            "response_format": {"type": "json_object"},
+        }
+        response = await self._post_openai(body)
+        data = self._extract_json(response)
+        expansions = data.get("expansions") if isinstance(data, dict) else None
+        if not expansions or not isinstance(expansions, list):
+            return [query]
+        cleaned = [item.strip() for item in expansions if isinstance(item, str) and item.strip()]
+        return cleaned or [query]
+
+    async def retrieve_papers(self, queries: list[str]) -> list[ArxivPaper]:
+        """Retrieve candidate papers from the arXiv API for each expanded query."""
+
+        seen: dict[str, ArxivPaper] = {}
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            for phrase in queries:
+                params = {
+                    "search_query": f"all:{phrase}",
+                    "start": 0,
+                    "max_results": self.arxiv_max_results,
+                    "sortBy": "relevance",
+                }
+                response = await client.get(self.arxiv_api_url, params=params, headers={"Accept": "application/atom+xml"})
+                response.raise_for_status()
+                for paper in self._parse_arxiv_feed(response.text):
+                    if paper.paper_id not in seen:
+                        seen[paper.paper_id] = paper
+        return list(seen.values())
+
+    async def rank_papers(
+        self, *, query: str, papers: list[ArxivPaper], top_k: int
+    ) -> list[tuple[ArxivPaper, float]]:
+        """Use Cohere re-ranking to score the candidate papers."""
+
+        if not self.cohere_api_key:
+            raise RuntimeError("Cohere API key is not configured")
+        if not papers:
+            return []
+
+        documents = [
+            {
+                "id": paper.paper_id,
+                "text": f"{paper.title}\n\n{paper.summary}",
+            }
+            for paper in papers
+        ]
+        payload = {
+            "model": self.cohere_model,
+            "query": query,
+            "documents": documents,
+            "top_n": min(top_k, len(documents)),
+        }
+        headers = {
+            "Authorization": f"Bearer {self.cohere_api_key}",
+            "Content-Type": "application/json",
+        }
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            response = await client.post(
+                f"{self.cohere_base_url}/v1/rerank", headers=headers, json=payload
+            )
+        response.raise_for_status()
+        data = response.json()
+        results: list[tuple[ArxivPaper, float]] = []
+        for item in data.get("results", []):
+            try:
+                index = int(item.get("index"))
+            except (TypeError, ValueError):
+                continue
+            if index < 0 or index >= len(papers):
+                continue
+            score_raw = item.get("relevance_score")
+            try:
+                score = float(score_raw)
+            except (TypeError, ValueError):
+                score = 0.0
+            results.append((papers[index], score))
+        results.sort(key=lambda pair: pair[1], reverse=True)
+        return results[:top_k]
+
+    async def explain_relevance(self, *, query: str, paper: ArxivPaper) -> str:
+        """Ask GPT-5 to summarise why the paper matters for the query."""
+
+        if not self.openai_api_key:
+            raise RuntimeError("OpenAI API key is not configured")
+
+        prompt = (
+            "You are assisting a researcher reviewing arXiv papers. "
+            "Given the user's description and the paper metadata, explain in 2 concise "
+            "sentences why this paper is relevant. Focus on concrete overlaps in methods, "
+            "findings, or applications."
+            "\n\nUser description:\n"
+            f"{query}\n"
+            "\nPaper title:\n"
+            f"{paper.title}\n"
+            "\nPaper summary:\n"
+            f"{paper.summary}\n"
+            "\nRespond with polished prose."
+        )
+        body: dict[str, Any] = {
+            "model": self.openai_model,
+            "input": prompt,
+        }
+        response = await self._post_openai(body)
+        return self._extract_text(response)
+
+    async def explain_many(
+        self, *, query: str, papers: list[tuple[ArxivPaper, float]]
+    ) -> list[tuple[ArxivPaper, float, str]]:
+        """Explain relevance for each ranked paper sequentially."""
+
+        results: list[tuple[ArxivPaper, float, str]] = []
+        for paper, score in papers:
+            reason = await self.explain_relevance(query=query, paper=paper)
+            results.append((paper, score, reason))
+        return results
+
+    async def orchestrate(
+        self,
+        *,
+        query: str,
+        top_k: int,
+    ) -> list[ResearchPaperSummary]:
+        """Convenience helper to execute the full pipeline without streaming."""
+
+        expansions = await self.expand_query(query)
+        papers = await self.retrieve_papers(expansions)
+        ranked = await self.rank_papers(query=query, papers=papers, top_k=top_k)
+        explained = await self.explain_many(query=query, papers=ranked)
+        return [paper.to_summary(score=score, reason=reason) for paper, score, reason in explained]
+
+    async def _post_openai(self, body: dict[str, Any]) -> dict[str, Any]:
+        headers = {
+            "Authorization": f"Bearer {self.openai_api_key}",
+            "Content-Type": "application/json",
+        }
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            response = await client.post(
+                f"{self.openai_base_url}/responses", headers=headers, json=body
+            )
+        response.raise_for_status()
+        return response.json()
+
+    @staticmethod
+    def _extract_json(response: dict[str, Any]) -> dict[str, Any]:
+        """Try to extract a JSON object from the OpenAI Responses payload."""
+
+        if not isinstance(response, dict):
+            return {}
+        if "output" in response:
+            for item in response.get("output", []):
+                if not isinstance(item, dict):
+                    continue
+                if item.get("type") == "output_text" and isinstance(item.get("text"), str):
+                    try:
+                        return json.loads(item["text"])
+                    except json.JSONDecodeError:
+                        continue
+                content = item.get("content")
+                if isinstance(content, list):
+                    for block in content:
+                        if (
+                            isinstance(block, dict)
+                            and block.get("type") in {"output_text", "text"}
+                            and isinstance(block.get("text"), str)
+                        ):
+                            try:
+                                return json.loads(block["text"])
+                            except json.JSONDecodeError:
+                                continue
+        for key in ("output_text", "text"):
+            raw = response.get(key)
+            if isinstance(raw, str):
+                try:
+                    return json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+        return {}
+
+    @staticmethod
+    def _extract_text(response: dict[str, Any]) -> str:
+        """Extract plain text from a Responses API payload."""
+
+        if not isinstance(response, dict):
+            return ""
+        if "output" in response:
+            for item in response.get("output", []):
+                if not isinstance(item, dict):
+                    continue
+                if item.get("type") == "output_text" and isinstance(item.get("text"), str):
+                    return item["text"].strip()
+                content = item.get("content")
+                if isinstance(content, list):
+                    for block in content:
+                        if (
+                            isinstance(block, dict)
+                            and block.get("type") in {"output_text", "text"}
+                            and isinstance(block.get("text"), str)
+                        ):
+                            return block["text"].strip()
+        for key in ("output_text", "text", "response"):
+            raw = response.get(key)
+            if isinstance(raw, str):
+                return raw.strip()
+        return ""
+
+    @staticmethod
+    def _parse_arxiv_feed(payload: str) -> list[ArxivPaper]:
+        """Parse an Atom XML feed returned by arXiv."""
+
+        ns = {"atom": "http://www.w3.org/2005/Atom"}
+        try:
+            root = ElementTree.fromstring(payload)
+        except ElementTree.ParseError:
+            return []
+        papers: list[ArxivPaper] = []
+        for entry in root.findall("atom:entry", ns):
+            paper_id = ResearchDiscoveryService._text(entry.find("atom:id", ns))
+            title = ResearchDiscoveryService._clean_text(
+                ResearchDiscoveryService._text(entry.find("atom:title", ns))
+            )
+            summary = ResearchDiscoveryService._clean_text(
+                ResearchDiscoveryService._text(entry.find("atom:summary", ns))
+            )
+            link = ""
+            for link_node in entry.findall("atom:link", ns):
+                if link_node.get("rel") == "alternate" and link_node.get("href"):
+                    link = link_node.get("href")
+                    break
+            published_raw = ResearchDiscoveryService._text(entry.find("atom:published", ns))
+            published_at = None
+            if published_raw:
+                try:
+                    published_at = datetime.fromisoformat(published_raw.replace("Z", "+00:00"))
+                except ValueError:
+                    published_at = None
+            authors = [
+                ResearchDiscoveryService._clean_text(ResearchDiscoveryService._text(author.find("atom:name", ns)))
+                for author in entry.findall("atom:author", ns)
+            ]
+            if not paper_id:
+                continue
+            papers.append(
+                ArxivPaper(
+                    paper_id=paper_id,
+                    title=title,
+                    summary=summary,
+                    url=link or paper_id,
+                    published_at=published_at,
+                    authors=[author for author in authors if author],
+                )
+            )
+        return papers
+
+    @staticmethod
+    def _text(node: ElementTree.Element | None) -> str:
+        return (node.text or "").strip() if node is not None else ""
+
+    @staticmethod
+    def _clean_text(value: str) -> str:
+        return " ".join(value.split())
+

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -48,6 +48,15 @@ const featureCards = [
     accent: "from-sky-400/80 to-indigo-500/80",
     pill: "Voice Notes",
   },
+  {
+    name: "Research Explorer",
+    description:
+      "Describe the paper you need and watch GPT-5 orchestrate an arXiv deep dive in real time.",
+    href: "/research-explorer",
+    icon: Sparkles,
+    accent: "from-cyan-400/80 to-blue-500/80",
+    pill: "Live RAG",
+  },
 ];
 
 const previewHighlights = [

--- a/frontend/app/research-explorer/page.tsx
+++ b/frontend/app/research-explorer/page.tsx
@@ -1,0 +1,534 @@
+"use client";
+
+import { type FormEvent, useCallback, useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  AlertTriangle,
+  BookOpen,
+  CheckCircle2,
+  ExternalLink,
+  ListChecks,
+  ListTree,
+  Loader2,
+  LucideIcon,
+  Search,
+  Sparkles,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
+
+interface ResearchPaperSummary {
+  paper_id: string;
+  title: string;
+  summary: string;
+  url: string;
+  published_at?: string | null;
+  authors: string[];
+  score?: number | null;
+  reason?: string | null;
+}
+
+type ResearchStreamEvent =
+  | {
+      type: "status";
+      stage: string;
+      message: string;
+      paper_id?: string;
+    }
+  | {
+      type: "expansion";
+      stage: string;
+      message: string;
+      expansions: string[];
+    }
+  | {
+      type: "retrieval";
+      stage: string;
+      message: string;
+      count: number;
+    }
+  | {
+      type: "ranking";
+      stage: string;
+      message: string;
+      total_candidates: number;
+      results: ResearchPaperSummary[];
+    }
+  | {
+      type: "explanation";
+      stage: string;
+      paper_id: string;
+      reason: string;
+    }
+  | {
+      type: "results";
+      stage: string;
+      message: string;
+      results: ResearchPaperSummary[];
+    }
+  | {
+      type: "error";
+      stage: string;
+      message: string;
+    };
+
+const STAGE_META: Record<
+  string,
+  { label: string; icon: LucideIcon; accent: string }
+> = {
+  expanding_query: {
+    label: "Query expansion",
+    icon: Sparkles,
+    accent: "from-emerald-400/70 to-cyan-400/70",
+  },
+  retrieving_candidates: {
+    label: "Retrieval",
+    icon: ListTree,
+    accent: "from-cyan-400/70 to-sky-400/70",
+  },
+  ranking: {
+    label: "Similarity ranking",
+    icon: ListChecks,
+    accent: "from-sky-400/70 to-indigo-400/70",
+  },
+  explaining: {
+    label: "Relevance narratives",
+    icon: BookOpen,
+    accent: "from-indigo-400/70 to-fuchsia-400/70",
+  },
+  complete: {
+    label: "Digest ready",
+    icon: CheckCircle2,
+    accent: "from-emerald-400/70 to-teal-400/70",
+  },
+  error: {
+    label: "Something went wrong",
+    icon: AlertTriangle,
+    accent: "from-rose-500/70 to-amber-400/70",
+  },
+};
+
+function getStageMeta(stage: string) {
+  return STAGE_META[stage] ?? {
+    label: stage.replace(/_/g, " "),
+    icon: Sparkles,
+    accent: "from-slate-500/70 to-slate-600/70",
+  };
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return null;
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return null;
+    return date.toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch (err) {
+    return null;
+  }
+}
+
+function formatScore(score?: number | null) {
+  if (score == null) return null;
+  return score.toFixed(2);
+}
+
+export default function ResearchExplorerPage(): JSX.Element {
+  const [query, setQuery] = useState(
+    "Autonomous agents that coordinate swarm robotics with vision transformers"
+  );
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [events, setEvents] = useState<ResearchStreamEvent[]>([]);
+  const [results, setResults] = useState<ResearchPaperSummary[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const resetState = useCallback(() => {
+    setEvents([]);
+    setResults([]);
+    setError(null);
+  }, []);
+
+  const handleEvent = useCallback((event: ResearchStreamEvent) => {
+    setEvents((prev) => [...prev, event]);
+
+    if (event.type === "ranking") {
+      setResults(event.results);
+    } else if (event.type === "explanation") {
+      setResults((prev) =>
+        prev.map((paper) =>
+          paper.paper_id === event.paper_id
+            ? { ...paper, reason: event.reason }
+            : paper
+        )
+      );
+    } else if (event.type === "results") {
+      setResults(event.results);
+    } else if (event.type === "error") {
+      setError(event.message);
+    }
+  }, []);
+
+  const submitSearch = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!query.trim()) {
+        setError("Please describe the paper you're looking for.");
+        return;
+      }
+
+      resetState();
+      setIsStreaming(true);
+
+      try {
+        const response = await fetch(`${API_BASE}/research/discover`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ query }),
+        });
+
+        if (!response.body) {
+          throw new Error("Streaming not supported by the backend response.");
+        }
+
+        if (!response.ok) {
+          const payload = await response.json().catch(() => null);
+          const message = payload?.detail ?? `Request failed with ${response.status}`;
+          throw new Error(message);
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+
+          let newlineIndex = buffer.indexOf("\n");
+          while (newlineIndex !== -1) {
+            const chunk = buffer.slice(0, newlineIndex).trim();
+            buffer = buffer.slice(newlineIndex + 1);
+            if (chunk) {
+              try {
+                handleEvent(JSON.parse(chunk) as ResearchStreamEvent);
+              } catch (err) {
+                console.error("Unable to parse stream chunk", err, chunk);
+              }
+            }
+            newlineIndex = buffer.indexOf("\n");
+          }
+        }
+
+        const finalChunk = buffer.trim();
+        if (finalChunk) {
+          try {
+            handleEvent(JSON.parse(finalChunk) as ResearchStreamEvent);
+          } catch (err) {
+            console.error("Unable to parse trailing chunk", err, finalChunk);
+          }
+        }
+      } catch (err) {
+        console.error("Research discovery failed", err);
+        setError(err instanceof Error ? err.message : "Unknown error");
+      } finally {
+        setIsStreaming(false);
+      }
+    },
+    [handleEvent, query, resetState]
+  );
+
+  const renderEventDetails = useCallback(
+    (event: ResearchStreamEvent) => {
+      switch (event.type) {
+        case "expansion":
+          return (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {event.expansions.map((expansion) => (
+                <span
+                  key={expansion}
+                  className="rounded-full border border-emerald-400/50 bg-emerald-400/10 px-3 py-1 text-xs text-emerald-200"
+                >
+                  {expansion}
+                </span>
+              ))}
+            </div>
+          );
+        case "retrieval":
+          return (
+            <p className="mt-2 text-xs text-slate-400">
+              {event.message}.
+            </p>
+          );
+        case "ranking":
+          return (
+            <p className="mt-2 text-xs text-slate-400">
+              {event.results.length} shortlisted from {event.total_candidates} candidates.
+            </p>
+          );
+        case "explanation": {
+          const paper = results.find((item) => item.paper_id === event.paper_id);
+          return (
+            <div className="mt-2 space-y-1">
+              {paper ? (
+                <p className="text-sm font-medium text-slate-200">{paper.title}</p>
+              ) : null}
+              <p className="text-xs text-slate-400">{event.reason}</p>
+            </div>
+          );
+        }
+        case "error":
+          return (
+            <p className="mt-2 text-xs text-rose-300">{event.message}</p>
+          );
+        case "results":
+          return (
+            <p className="mt-2 text-xs text-emerald-200">
+              {event.results.length} papers ready to review.
+            </p>
+          );
+        default:
+          return null;
+      }
+    },
+    [results]
+  );
+
+  const timeline = useMemo(() => {
+    if (events.length === 0) {
+      return (
+        <div className="rounded-3xl border border-slate-800/70 bg-slate-900/50 p-8 text-center">
+          <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-slate-800/70 text-emerald-300">
+            <Sparkles className="h-6 w-6" />
+          </div>
+          <h3 className="mt-4 text-lg font-semibold text-slate-100">
+            Awaiting your research brief
+          </h3>
+          <p className="mt-2 text-sm text-slate-400">
+            Describe the paper you need and watch each reasoning step stream in like an OpenAI console.
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <ul className="space-y-4">
+        {events.map((event, index) => {
+          const meta = getStageMeta(event.stage);
+          const isActive = index === events.length - 1;
+          const Icon = meta.icon;
+          return (
+            <li
+              key={`${event.type}-${index}`}
+              className="relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-950/70 p-5 shadow-lg"
+            >
+              <div
+                className={cn(
+                  "absolute inset-y-0 left-0 w-1 bg-gradient-to-b",
+                  meta.accent
+                )}
+              />
+              <div
+                className={cn(
+                  "relative flex items-start gap-4",
+                  isActive ? "opacity-100" : "opacity-90"
+                )}
+              >
+                <div
+                  className={cn(
+                    "flex h-10 w-10 items-center justify-center rounded-2xl border",
+                    isActive
+                      ? "border-emerald-400/70 bg-emerald-400/10 text-emerald-200"
+                      : "border-slate-800 bg-slate-900 text-slate-300"
+                  )}
+                >
+                  <Icon className="h-5 w-5" />
+                </div>
+                <div className="flex-1">
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="text-sm font-semibold uppercase tracking-wide text-slate-200">
+                      {meta.label}
+                    </p>
+                    {isActive && isStreaming ? (
+                      <span className="inline-flex items-center gap-1 rounded-full border border-emerald-400/40 bg-emerald-400/10 px-2 py-0.5 text-[10px] uppercase tracking-wider text-emerald-200">
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                        Streaming
+                      </span>
+                    ) : null}
+                  </div>
+                  {"message" in event ? (
+                    <p className="mt-1 text-sm text-slate-300">{event.message}</p>
+                  ) : null}
+                  {renderEventDetails(event)}
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    );
+  }, [events, isStreaming, renderEventDetails]);
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950" />
+      <div className="pointer-events-none absolute -left-24 top-10 h-72 w-72 rounded-full bg-emerald-500/20 blur-3xl" />
+      <div className="pointer-events-none absolute -right-24 bottom-0 h-80 w-80 rounded-full bg-cyan-500/20 blur-3xl" />
+
+      <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 py-12 sm:px-10 lg:px-16">
+        <header className="mb-10 flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <p className="text-sm uppercase tracking-[0.35em] text-emerald-200/80">
+              Research Explorer
+            </p>
+            <h1 className="mt-3 text-4xl font-semibold leading-tight text-slate-50 sm:text-5xl">
+              Streamed RAG for instant paper scouting.
+            </h1>
+            <p className="mt-4 max-w-2xl text-base text-slate-300">
+              Describe the research you need and watch GPT-5 expand your request, search arXiv, rerank with Cohere, and narrate why each paper matters—all in an OpenAI-style live trace.
+            </p>
+          </div>
+          <Button
+            asChild
+            variant="ghost"
+            className="self-start text-slate-300 hover:text-slate-50"
+          >
+            <Link href="/">Back to studio</Link>
+          </Button>
+        </header>
+
+        <section className="rounded-3xl border border-slate-800/70 bg-slate-950/60 p-8 shadow-2xl backdrop-blur">
+          <form onSubmit={submitSearch} className="space-y-6">
+            <div className="space-y-3">
+              <label className="text-sm font-medium uppercase tracking-wide text-slate-300">
+                Describe the paper or problem
+              </label>
+              <textarea
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                rows={4}
+                className="w-full rounded-2xl border border-slate-800 bg-slate-900/80 px-4 py-3 text-base text-slate-100 shadow-inner focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+                placeholder="e.g. Foundation models for temporal graph forecasting in climate risk analysis"
+              />
+            </div>
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <p className="text-xs text-slate-400">
+                We'll expand your search with GPT-5, run arXiv retrieval, Cohere re-ranking, and send back GPT-5 explanations for the top matches.
+              </p>
+              <Button
+                type="submit"
+                disabled={isStreaming}
+                className="group bg-emerald-400 text-slate-950 hover:bg-emerald-300"
+              >
+                <span className="inline-flex items-center gap-2 text-sm font-semibold">
+                  {isStreaming ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Streaming
+                    </>
+                  ) : (
+                    <>
+                      <Search className="h-4 w-4 transition-transform group-hover:scale-110" />
+                      Start discovery
+                    </>
+                  )}
+                </span>
+              </Button>
+            </div>
+          </form>
+          {error ? (
+            <div className="mt-6 rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
+              {error}
+            </div>
+          ) : null}
+        </section>
+
+        <section className="mt-12 grid gap-8 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
+          <div className="space-y-4">
+            <h2 className="text-sm uppercase tracking-[0.3em] text-slate-400">
+              Live reasoning trace
+            </h2>
+            {timeline}
+          </div>
+          <div className="space-y-4">
+            <h2 className="text-sm uppercase tracking-[0.3em] text-slate-400">
+              Recommended papers
+            </h2>
+            {results.length === 0 ? (
+              <div className="rounded-3xl border border-slate-800/70 bg-slate-950/60 p-8 text-center text-sm text-slate-400">
+                Results will appear here once the pipeline finishes ranking and explaining the matches.
+              </div>
+            ) : (
+              <div className="space-y-6">
+                {results.map((paper, index) => {
+                  const formattedDate = formatDate(paper.published_at);
+                  const formattedScore = formatScore(paper.score ?? undefined);
+                  return (
+                    <article
+                      key={paper.paper_id}
+                      className="group relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-xl transition hover:border-emerald-400/60 hover:bg-slate-950/80"
+                    >
+                      <div className="absolute inset-x-6 top-0 h-px bg-gradient-to-r from-transparent via-emerald-400/60 to-transparent opacity-0 transition group-hover:opacity-100" />
+                      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                        <div>
+                          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300/80">
+                            #{index + 1} Recommendation
+                          </p>
+                          <h3 className="mt-2 text-xl font-semibold text-slate-50">
+                            <a
+                              href={paper.url}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="inline-flex items-center gap-2 text-slate-50 hover:text-emerald-200"
+                            >
+                              {paper.title}
+                              <ExternalLink className="h-4 w-4" />
+                            </a>
+                          </h3>
+                          <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-slate-400">
+                            {paper.authors.length > 0 ? (
+                              <span>{paper.authors.join(", ")}</span>
+                            ) : null}
+                            {formattedDate ? (
+                              <span className="rounded-full border border-slate-700/80 px-2 py-0.5 text-[11px] uppercase tracking-wide">
+                                {formattedDate}
+                              </span>
+                            ) : null}
+                            {formattedScore ? (
+                              <span className="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2 py-0.5 text-[11px] uppercase tracking-wide text-emerald-200">
+                                Score {formattedScore}
+                              </span>
+                            ) : null}
+                          </div>
+                        </div>
+                      </div>
+                      {paper.reason ? (
+                        <p className="mt-4 rounded-2xl border border-emerald-400/30 bg-emerald-400/10 p-4 text-sm text-emerald-100">
+                          {paper.reason}
+                        </p>
+                      ) : (
+                        <p className="mt-4 rounded-2xl border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300">
+                          Waiting for GPT-5 to finish the relevance narrative...
+                        </p>
+                      )}
+                      <p className="mt-4 text-sm text-slate-300">
+                        {paper.summary}
+                      </p>
+                    </article>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a FastAPI `/research/discover` route that streams GPT-5 query expansion, arXiv retrieval, Cohere ranking, and explanation steps
- introduce a dedicated research discovery service, schema, and configuration knobs to orchestrate the RAG workflow
- build the Research Explorer Next.js page with OpenAI-style reasoning timeline and surfaced recommendations, plus a landing card entry point

## Testing
- poetry run pytest *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68d83c5a6da8832781e99ee77e9620e3