### PR TITLE
Add realtime assistant card to landing page

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -71,6 +71,15 @@ const featureCards = [
     accent: "from-cyan-400/80 to-blue-500/80",
     pill: "Live RAG",
   },
+  {
+    name: "Realtime Assistant",
+    description:
+      "Step into a live co-pilot that blends voice, context, and automation into a single responsive teammate.",
+    href: "/realtime-assistant",
+    icon: Star,
+    accent: "from-emerald-300/80 to-teal-400/80",
+    pill: "Live Copilot",
+  },
 ];
 
 const previewHighlights: Highlight[] = [


### PR DESCRIPTION
## Summary
- add a landing page feature card that links to the realtime assistant experience
- highlight the realtime assistant with dedicated description, accent, and label

## Testing
- npm run lint *(fails: existing react/no-unescaped-entities warning in app/research-explorer/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d8461ecddc8327b46d7b198f34fcc0