### PR TITLE
Switch realtime assistant to gpt-realtime and add periodic UI capture

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -14,7 +14,7 @@ class Settings(BaseSettings):
         default="https://api.openai.com/v1", alias="OPENAI_API_BASE_URL"
     )
     openai_realtime_model: str = Field(
-        default="gpt-4o-realtime-preview-2024-12-17", alias="OPENAI_REALTIME_MODEL"
+        default="gpt-realtime", alias="OPENAI_REALTIME_MODEL"
     )
     openai_realtime_voice: str = Field(default="verse", alias="OPENAI_REALTIME_VOICE")
     openai_realtime_instructions: str | None = Field(

--- a/frontend/components/realtime-conversation.tsx
+++ b/frontend/components/realtime-conversation.tsx
@@ -354,6 +354,40 @@ export function RealtimeConversationPanel({
     };
   }, [resetConnection]);
 
+  useEffect(() => {
+    if (!isActive || !onShareVisionFrame) {
+      return undefined;
+    }
+
+    let isCancelled = false;
+    let timeoutId: number | undefined;
+
+    const shareLoop = async () => {
+      if (isCancelled) {
+        return;
+      }
+
+      try {
+        await onShareVisionFrame();
+      } catch (err) {
+        console.warn("Unable to share periodic context frame", err);
+      }
+
+      if (!isCancelled) {
+        timeoutId = window.setTimeout(shareLoop, 2000);
+      }
+    };
+
+    void shareLoop();
+
+    return () => {
+      isCancelled = true;
+      if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+  }, [isActive, onShareVisionFrame]);
+
   return (
     <div className="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900/40">
       <Heading as="h2" size="4" className="mb-3 font-heading">


### PR DESCRIPTION
## Summary
- set the backend realtime model default to gpt-realtime to match the production model
- start an interval in the realtime conversation panel to capture and upload UI screenshots every two seconds while a call is active

## Testing
- poetry run pytest tests/test_realtime.py *(fails: realtime dependencies not configured in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d84fd448ac83278895dc7818c77c02