### PR TITLE
Bypass vision analyzer and surface raw frames to realtime clients

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -12,7 +12,6 @@ from app.services.realtime import RealtimeSessionClient
 from app.services.research import ResearchDiscoveryService
 from app.services.storage import S3AudioStorage, StorageServiceError
 from app.services.tutor import TutorModeService
-from app.services.vision import VisionAnalyzer
 from app.services.context_storage import get_context_storage
 
 
@@ -186,25 +185,3 @@ def get_payment_service() -> StripePaymentService:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
 
 
-@lru_cache
-def _get_vision_analyzer() -> VisionAnalyzer:
-    """Return a singleton vision analyzer instance."""
-    
-    settings = _get_settings()
-    if not settings.openai_api_key:
-        raise ValueError("OpenAI API key is not configured for vision analysis")
-    
-    return VisionAnalyzer(
-        api_key=settings.openai_api_key,
-        base_url=settings.openai_api_base_url,
-        model="gpt-4o",
-    )
-
-
-def get_vision_analyzer() -> VisionAnalyzer:
-    """FastAPI dependency that provides the vision analyzer."""
-    
-    try:
-        return _get_vision_analyzer()
-    except ValueError as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc

--- a/backend/app/schemas/realtime.py
+++ b/backend/app/schemas/realtime.py
@@ -18,6 +18,10 @@ class RealtimeSessionToken(BaseModel):
     model: str = Field(description="Realtime model configured for the session")
     url: str = Field(description="Endpoint used to exchange SDP offers with OpenAI")
     voice: str | None = Field(default=None, description="Voice configured for audio output")
+    latest_frame_base64: str | None = Field(
+        default=None,
+        description="Most recent raw frame captured from the client, encoded as base64 JPEG",
+    )
 
 
 class VisionFrameRequest(BaseModel):


### PR DESCRIPTION
## Summary
- remove the vision analyzer dependency when ingesting frames and retain the raw payload for reuse
- extend the vision context and realtime session response so clients can forward the latest base64 frame directly to GPT Realtime
- clean up unused dependency wiring for the vision analyzer

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68d85306aa188327bffbb8dc9a4f43dc