### PR TITLE
Fix realtime session context retrieval

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -166,24 +166,12 @@ async def create_realtime_session(
     """Return an ephemeral client secret for establishing WebRTC sessions with visual context."""
 
     # Get the most recent visual context
-    recent_context = None
-    for session_id in list(context_storage._storage.keys()):
-        context = context_storage.get_context(session_id)
-        if context and (recent_context is None or context.timestamp > recent_context.timestamp):
-            recent_context = context
+    recent_context = context_storage.get_latest_context()
 
     # Enhance instructions with visual context if available
     enhanced_instructions = None
     latest_frame_base64: str | None = None
     if recent_context:
-        if recent_context:
-            print(f"Recent context image base64: {recent_context.image_base64}")
-            print(f"Recent context description: {recent_context.description}")
-            print(f"Recent context key elements: {recent_context.key_elements}")
-            print(f"Recent context user intent: {recent_context.user_intent}")
-            print(f"Recent context actionable items: {recent_context.actionable_items}")
-        else:
-            print("No recent context available.")
         latest_frame_base64 = recent_context.image_base64
         enhanced_instructions = f"""You are an AI assistant that can see and understand the user's current screen context.
 

--- a/backend/tests/test_realtime.py
+++ b/backend/tests/test_realtime.py
@@ -5,9 +5,11 @@ from datetime import datetime, timedelta, timezone
 
 from fastapi.testclient import TestClient
 
-from app.api.dependencies import get_realtime_client
+from app.api.dependencies import get_context_storage, get_realtime_client
 from app.main import app
+from app.services.context_storage import ContextStorage
 from app.services.realtime import RealtimeSession
+from app.services.vision import VisionContext
 
 
 def test_realtime_session_requires_configuration() -> None:
@@ -50,6 +52,63 @@ def test_realtime_session_success() -> None:
     assert payload["url"] == "https://api.example.com/v1/realtime?model=gpt-realtime-test"
     # Expires at should round-trip as ISO 8601 string
     assert datetime.fromisoformat(payload["expires_at"]) == expires
+
+
+def test_realtime_session_includes_latest_frame() -> None:
+    """The latest stored vision frame should be exposed in the session payload."""
+
+    expires = datetime.now(timezone.utc) + timedelta(minutes=5)
+    session = RealtimeSession(
+        session_id="sess_test",
+        client_secret="secret_123",
+        expires_at=expires,
+        model="gpt-realtime-test",
+        voice="alloy",
+        base_url="https://api.example.com/v1",
+    )
+
+    class FakeRealtimeClient:
+        async def create_ephemeral_session(self) -> RealtimeSession:  # noqa: D401
+            return session
+
+    storage = ContextStorage()
+    now = datetime.now(timezone.utc)
+    older_context = VisionContext(
+        description="Older frame",
+        key_elements=["button"],
+        user_intent="testing",
+        actionable_items=["click"],
+        timestamp=now - timedelta(seconds=30),
+        source="ui",
+        image_base64=base64.b64encode(b"older").decode("ascii"),
+        captured_at=now - timedelta(seconds=30),
+    )
+    latest_context = VisionContext(
+        description="Latest frame",
+        key_elements=["input"],
+        user_intent="testing",
+        actionable_items=["type"],
+        timestamp=now,
+        source="ui",
+        image_base64=base64.b64encode(b"latest").decode("ascii"),
+        captured_at=now,
+    )
+
+    storage.store_context("session_old", older_context)
+    storage.store_context("session_new", latest_context)
+
+    with TestClient(app) as client:
+        app.dependency_overrides[get_realtime_client] = lambda: FakeRealtimeClient()
+        app.dependency_overrides[get_context_storage] = lambda: storage
+        try:
+            response = client.post("/api/v1/realtime/session")
+        finally:
+            app.dependency_overrides.pop(get_realtime_client, None)
+            app.dependency_overrides.pop(get_context_storage, None)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["latest_frame_base64"] == latest_context.image_base64
 
 
 def test_vision_frame_endpoint_accepts_valid_image() -> None:


### PR DESCRIPTION
## Summary
- add a thread-safe helper on ContextStorage to fetch the latest valid vision context
- update the realtime session route to rely on the new helper and clean up debugging prints
- extend the realtime tests to assert that the freshest frame is echoed in the session payload

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'app' during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68d85f72a3248327975f5ae3f7f3babd