### PR TITLE
Add realtime UI overlay support for assistant guidance

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -213,7 +213,15 @@ Visual context summary:
 
 A raw base64-encoded frame captured by the client is available for immediate multimodal processing.
 
-Use this visual context to provide more relevant and helpful responses. You can reference what you see on their screen, help them with tasks they're working on, or answer questions about the content they're viewing. Be specific about what you observe and how you can assist them with their current activity."""
+Use this visual context to provide more relevant and helpful responses. You can reference what you see on their screen, help them with tasks they're working on, or answer questions about the content they're viewing. Be specific about what you observe and how you can assist them with their current activity.
+
+You can guide the user with lightweight UI overlays. Include inline commands in your response using the format [[overlay|{{"selector":"[data-ui='nav-home']","label":"Tap \"Back to studio\"","shape":"circle","duration_ms":6000}}]]. Supported selectors include:
+- [data-ui='nav-home'] — "Back to studio" navigation button
+- [data-ui='nav-emotion-console'] — "Open emotion console" shortcut
+- [data-ui='action-share-view'] — "Share current view" capture button
+- [data-ui='action-mark-fresh'] — "Mark context as fresh" confirmation button
+
+Emit [[overlay|{{"action":"clear"}}]] when highlights are no longer required. Continue providing natural language guidance alongside any overlay instructions."""
 
     try:
         # Create a new client with enhanced instructions

--- a/frontend/app/realtime-assistant/page.tsx
+++ b/frontend/app/realtime-assistant/page.tsx
@@ -1,13 +1,23 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import html2canvas from "html2canvas";
 import { Theme, Heading, Text } from "@radix-ui/themes";
 import "@radix-ui/themes/styles.css";
 
-import RealtimeConversationPanel from "@/components/realtime-conversation";
+import RealtimeConversationPanel, {
+  UiOverlayInstruction,
+} from "@/components/realtime-conversation";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
@@ -57,6 +67,7 @@ export default function RealtimeAssistantPage(): JSX.Element {
   const surfaceRef = useRef<HTMLDivElement | null>(null);
   const timeoutRef = useRef<number>();
   const shareInFlightRef = useRef(false);
+  const overlayTimeoutsRef = useRef<Map<string, number>>(new Map());
 
   const [shareStatus, setShareStatus] = useState<ShareStatus>("idle");
   const [shareMessage, setShareMessage] = useState<string | null>(null);
@@ -64,6 +75,22 @@ export default function RealtimeAssistantPage(): JSX.Element {
   const [lastSharedPreview, setLastSharedPreview] = useState<string | null>(
     null
   );
+  const [overlayInstructions, setOverlayInstructions] = useState<
+    ActiveOverlayInstruction[]
+  >([]);
+  const [computedOverlays, setComputedOverlays] = useState<
+    ComputedOverlay[]
+  >([]);
+
+  useEffect(() => {
+    const timeouts = overlayTimeoutsRef.current;
+    return () => {
+      timeouts.forEach((handle) => {
+        window.clearTimeout(handle);
+      });
+      timeouts.clear();
+    };
+  }, []);
 
   useEffect(() => {
     return () => {
@@ -171,6 +198,188 @@ export default function RealtimeAssistantPage(): JSX.Element {
     [shareStatus]
   );
 
+  const scheduleOverlayRemoval = useCallback((id: string, durationMs = 8000) => {
+    if (!durationMs || durationMs < 0) {
+      return;
+    }
+
+    const existing = overlayTimeoutsRef.current.get(id);
+    if (existing) {
+      window.clearTimeout(existing);
+    }
+
+    const handle = window.setTimeout(() => {
+      setOverlayInstructions((prev) =>
+        prev.filter((instruction) => instruction.id !== id)
+      );
+      overlayTimeoutsRef.current.delete(id);
+    }, durationMs);
+
+    overlayTimeoutsRef.current.set(id, handle);
+  }, []);
+
+  const handleOverlayInstruction = useCallback(
+    (instruction: UiOverlayInstruction) => {
+      if (instruction.action === "clear") {
+        setOverlayInstructions((prev) => {
+          if (!instruction.id && !instruction.selector) {
+            overlayTimeoutsRef.current.forEach((handle) => {
+              window.clearTimeout(handle);
+            });
+            overlayTimeoutsRef.current.clear();
+            return [];
+          }
+
+          const remaining: ActiveOverlayInstruction[] = [];
+          prev.forEach((overlay) => {
+            const matchesId = instruction.id
+              ? overlay.id === instruction.id
+              : true;
+            const matchesSelector = instruction.selector
+              ? overlay.selector === instruction.selector
+              : true;
+            const shouldRemove = matchesId && matchesSelector;
+
+            if (shouldRemove) {
+              const timer = overlayTimeoutsRef.current.get(overlay.id);
+              if (timer) {
+                window.clearTimeout(timer);
+                overlayTimeoutsRef.current.delete(overlay.id);
+              }
+            } else {
+              remaining.push(overlay);
+            }
+          });
+
+          return remaining;
+        });
+        return;
+      }
+
+      const id =
+        instruction.id ??
+        `overlay-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const shape: "circle" | "rect" = instruction.shape ?? "circle";
+
+      setOverlayInstructions((prev) => {
+        const filtered = prev.filter((overlay) => overlay.id !== id);
+        return [
+          ...filtered,
+          {
+            ...instruction,
+            id,
+            shape,
+          },
+        ];
+      });
+
+      scheduleOverlayRemoval(id, instruction.durationMs);
+    },
+    [scheduleOverlayRemoval]
+  );
+
+  useLayoutEffect(() => {
+    const surface = surfaceRef.current;
+    if (!surface) {
+      setComputedOverlays([]);
+      return;
+    }
+
+    const computeOverlays = () => {
+      const host = surfaceRef.current;
+      if (!host) {
+        setComputedOverlays([]);
+        return;
+      }
+
+      const hostRect = host.getBoundingClientRect();
+      const results: ComputedOverlay[] = [];
+
+      overlayInstructions.forEach((overlay) => {
+        let rect: DOMRectLike | null = null;
+
+        if (overlay.selector) {
+          const target = host.querySelector(overlay.selector);
+          if (target instanceof HTMLElement) {
+            const targetRect = target.getBoundingClientRect();
+            rect = {
+              left: targetRect.left - hostRect.left + host.scrollLeft,
+              top: targetRect.top - hostRect.top + host.scrollTop,
+              width: targetRect.width,
+              height: targetRect.height,
+            };
+          }
+        }
+
+        if (!rect && overlay.coords) {
+          rect = {
+            left: overlay.coords.x,
+            top: overlay.coords.y,
+            width: overlay.coords.width,
+            height: overlay.coords.height,
+          };
+        }
+
+        if (!rect) {
+          return;
+        }
+
+        const padding = overlay.padding ?? 12;
+
+        if (overlay.shape === "circle") {
+          const diameter = Math.max(rect.width, rect.height) + padding * 2;
+          const centerX = rect.left + rect.width / 2;
+          const centerY = rect.top + rect.height / 2;
+          results.push({
+            ...overlay,
+            left: centerX - diameter / 2,
+            top: centerY - diameter / 2,
+            width: diameter,
+            height: diameter,
+          });
+          return;
+        }
+
+        results.push({
+          ...overlay,
+          left: rect.left - padding,
+          top: rect.top - padding,
+          width: rect.width + padding * 2,
+          height: rect.height + padding * 2,
+        });
+      });
+
+      setComputedOverlays(results);
+    };
+
+    computeOverlays();
+
+    const handleResize = () => computeOverlays();
+    const handleScroll = () => computeOverlays();
+
+    window.addEventListener("resize", handleResize);
+    document.addEventListener("scroll", handleScroll, true);
+
+    const observer = new ResizeObserver(() => computeOverlays());
+    observer.observe(surface);
+
+    overlayInstructions.forEach((overlay) => {
+      if (!overlay.selector) {
+        return;
+      }
+      const element = surface.querySelector(overlay.selector);
+      if (element instanceof Element) {
+        observer.observe(element);
+      }
+    });
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      document.removeEventListener("scroll", handleScroll, true);
+      observer.disconnect();
+    };
+  }, [overlayInstructions]);
+
   return (
     <Theme appearance="dark">
       <main className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
@@ -180,6 +389,45 @@ export default function RealtimeAssistantPage(): JSX.Element {
           className="relative mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 pb-20 pt-10 sm:px-10"
           ref={surfaceRef}
         >
+          {computedOverlays.length > 0 ? (
+            <div className="pointer-events-none absolute inset-0 z-30">
+              {computedOverlays.map((overlay) => (
+                <div
+                  key={overlay.id}
+                  className="absolute"
+                  style={{
+                    left: overlay.left,
+                    top: overlay.top,
+                    width: overlay.width,
+                    height: overlay.height,
+                  }}
+                >
+                  <div
+                    className={cn(
+                      "relative h-full w-full border-2 border-emerald-400/80 bg-emerald-400/10 shadow-[0_0_0_6px_rgba(16,185,129,0.2)] backdrop-blur-sm",
+                      overlay.shape === "circle"
+                        ? "rounded-full"
+                        : "rounded-2xl"
+                    )}
+                  >
+                    <div
+                      className={cn(
+                        "pointer-events-none absolute inset-0 animate-ping border-2 border-emerald-400/40",
+                        overlay.shape === "circle"
+                          ? "rounded-full"
+                          : "rounded-2xl"
+                      )}
+                    />
+                    {overlay.label ? (
+                      <span className="pointer-events-none absolute -top-3 left-1/2 -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-full bg-emerald-400 px-3 py-1 text-xs font-semibold text-emerald-950 shadow-lg">
+                        {overlay.label}
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : null}
           <div className="pointer-events-none absolute inset-x-0 top-16 mx-auto h-72 max-w-3xl rounded-full bg-emerald-500/10 blur-3xl" />
           <header className="relative z-10 flex flex-wrap items-center justify-between gap-4 rounded-2xl border border-slate-800/60 bg-slate-900/70 px-6 py-5 shadow-[0_12px_40px_-24px_rgba(15,118,110,0.8)] backdrop-blur">
             <div>
@@ -195,12 +443,14 @@ export default function RealtimeAssistantPage(): JSX.Element {
               <Button
                 variant="ghost"
                 asChild
+                data-ui="nav-home"
                 className="text-slate-200 hover:text-slate-50 hover:bg-slate-800/60"
               >
                 <Link href="/">Back to studio</Link>
               </Button>
               <Button
                 asChild
+                data-ui="nav-emotion-console"
                 className="bg-emerald-400 text-slate-950 shadow-[0_12px_30px_-18px_rgba(16,185,129,0.9)] transition-transform hover:-translate-y-0.5 hover:bg-emerald-300"
               >
                 <Link href="/emotion-console">Open emotion console</Link>
@@ -212,6 +462,7 @@ export default function RealtimeAssistantPage(): JSX.Element {
             <RealtimeConversationPanel
               onShareVisionFrame={() => shareUiContext({ silent: true })}
               visionFrameIntervalMs={15000} // 15 seconds - adjust this value to change frequency
+              onOverlayInstruction={handleOverlayInstruction}
             />
 
             <div className="space-y-5 rounded-2xl border border-slate-800/60 bg-slate-900/75 p-6 shadow-[0_25px_50px_-20px_rgba(15,23,42,0.65)] backdrop-blur">
@@ -268,6 +519,7 @@ export default function RealtimeAssistantPage(): JSX.Element {
                     void shareUiContext().catch(() => undefined);
                   }}
                   disabled={shareStatus === "capturing"}
+                  data-ui="action-share-view"
                   className="flex-1 bg-emerald-400 text-slate-950 shadow-[0_16px_40px_-24px_rgba(16,185,129,0.9)] transition-transform hover:-translate-y-0.5 hover:bg-emerald-300 disabled:cursor-not-allowed disabled:opacity-80"
                 >
                   {shareStatus === "capturing"
@@ -292,6 +544,7 @@ export default function RealtimeAssistantPage(): JSX.Element {
                     }
                   }}
                   disabled={!lastSharedAt}
+                  data-ui="action-mark-fresh"
                   className="flex-1 border-slate-700/70 bg-slate-900/40 text-slate-200 transition hover:bg-slate-800/70 hover:text-slate-50 disabled:border-slate-800/60 disabled:text-slate-500"
                 >
                   Mark context as fresh
@@ -309,3 +562,17 @@ export default function RealtimeAssistantPage(): JSX.Element {
     </Theme>
   );
 }
+
+type ActiveOverlayInstruction = UiOverlayInstruction & {
+  id: string;
+  shape: "circle" | "rect";
+};
+
+type DOMRectLike = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+type ComputedOverlay = ActiveOverlayInstruction & DOMRectLike;


### PR DESCRIPTION
## Summary
- add overlay command parsing to realtime conversation handling so assistant messages can trigger UI highlights
- render persistent overlay layer in the realtime assistant workspace with timed removal and instrument key buttons with selectors
- document the overlay command format in the backend instructions passed to the realtime model

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d8772054d8832789e310264ffb8d9e