### PR TITLE
Fix realtime assistant call drops by adding STUN servers

### DIFF
--- a/frontend/components/realtime-conversation.tsx
+++ b/frontend/components/realtime-conversation.tsx
@@ -24,6 +24,13 @@ type TranscriptEntry = {
   text: string;
 };
 
+const RTC_CONFIGURATION: RTCConfiguration = {
+  iceServers: [
+    { urls: "stun:stun.cloudflare.com:3478" },
+    { urls: "stun:stun.l.google.com:19302" },
+  ],
+};
+
 const waitForIceGathering = (pc: RTCPeerConnection): Promise<void> =>
   new Promise((resolve) => {
     if (pc.iceGatheringState === "complete") {
@@ -243,7 +250,7 @@ export function RealtimeConversationPanel({
           ? token.latest_frame_base64.trim()
           : null;
 
-      const pc = new RTCPeerConnection();
+      const pc = new RTCPeerConnection(RTC_CONFIGURATION);
       peerConnectionRef.current = pc;
 
       pc.ontrack = (event) => {


### PR DESCRIPTION
## Summary
- add explicit STUN servers to the realtime conversation WebRTC configuration so calls stop failing during ICE negotiation
- reuse the shared configuration when creating the RTCPeerConnection instance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8baf0d22c83278cbf975d4f6a9a40