### PR TITLE
Add DOM-aware GPT-5 context for realtime assistant

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -13,6 +13,7 @@ from app.services.research import ResearchDiscoveryService
 from app.services.storage import S3AudioStorage, StorageServiceError
 from app.services.tutor import TutorModeService
 from app.services.context_storage import get_context_storage
+from app.services.vision import VisionAnalyzer
 
 
 def get_settings() -> Settings:
@@ -48,6 +49,30 @@ def get_realtime_client() -> RealtimeSessionClient:
         voice=settings.openai_realtime_voice,
         instructions=settings.openai_realtime_instructions,
     )
+
+
+@lru_cache
+def _get_vision_analyzer() -> VisionAnalyzer:
+    """Return a singleton vision analyzer configured for GPT-5."""
+
+    settings = _get_settings()
+    if not settings.openai_api_key:
+        raise ValueError("Vision analysis is not configured")
+
+    return VisionAnalyzer(
+        api_key=settings.openai_api_key,
+        base_url=settings.openai_api_base_url,
+        model=settings.openai_vision_model,
+    )
+
+
+def get_vision_analyzer() -> VisionAnalyzer:
+    """FastAPI dependency for the vision analyzer."""
+
+    try:
+        return _get_vision_analyzer()
+    except ValueError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
 
 
 @lru_cache

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -20,6 +20,9 @@ class Settings(BaseSettings):
     openai_realtime_instructions: str | None = Field(
         default=None, alias="OPENAI_REALTIME_INSTRUCTIONS"
     )
+    openai_vision_model: str = Field(
+        default="gpt-5.0", alias="OPENAI_VISION_MODEL"
+    )
     openai_annotation_model: str = Field(
         default="gpt-5.0", alias="OPENAI_ANNOTATION_MODEL"
     )

--- a/backend/app/schemas/realtime.py
+++ b/backend/app/schemas/realtime.py
@@ -3,10 +3,21 @@
 from __future__ import annotations
 
 from datetime import datetime
-
 from typing import Literal
 
 from pydantic import BaseModel, Field
+
+
+class HighlightInstruction(BaseModel):
+    """Instruction for the client to highlight a DOM element."""
+
+    selector: str = Field(description="CSS selector targeting the DOM node")
+    action: Literal["highlight"] = Field(
+        default="highlight", description="Type of UI affordance to perform"
+    )
+    reason: str | None = Field(
+        default=None, description="Why the element should be highlighted"
+    )
 
 
 class RealtimeSessionToken(BaseModel):
@@ -22,6 +33,18 @@ class RealtimeSessionToken(BaseModel):
         default=None,
         description="Most recent raw frame captured from the client, encoded as base64 JPEG",
     )
+    dom_summary: str | None = Field(
+        default=None,
+        description="High level summary of the most recent DOM snapshot analyzed by the assistant",
+    )
+    dom_snapshot: str | None = Field(
+        default=None,
+        description="Raw DOM digest provided by the client for the latest vision frame",
+    )
+    highlight_instructions: list[HighlightInstruction] | None = Field(
+        default=None,
+        description="Structured highlight suggestions derived from the analyzed context",
+    )
 
 
 class VisionFrameRequest(BaseModel):
@@ -34,6 +57,10 @@ class VisionFrameRequest(BaseModel):
     source: Literal["camera", "ui"] = Field(
         default="camera",
         description="Originating surface for the submitted frame (camera or UI screenshot)",
+    )
+    dom_snapshot: str | None = Field(
+        default=None,
+        description="Serialized DOM digest captured alongside the frame (JSON string)",
     )
 
 
@@ -50,5 +77,16 @@ class VisionFrameResponse(BaseModel):
     )
     source: Literal["camera", "ui"] = Field(
         description="Originating surface for the submitted frame (camera or UI screenshot)",
+    )
+    description: str | None = Field(
+        default=None, description="Structured description extracted from the frame"
+    )
+    dom_summary: str | None = Field(
+        default=None,
+        description="Summary of the DOM provided with the frame, if available",
+    )
+    highlight_instructions: list[HighlightInstruction] | None = Field(
+        default=None,
+        description="Highlight suggestions generated from the latest analysis",
     )
 


### PR DESCRIPTION
## Summary
- capture DOM digests alongside UI screenshots and send them to the backend vision endpoint
- analyze frames with the GPT-5 vision model to produce DOM summaries and structured highlight instructions for realtime sessions
- surface highlight directives in the realtime client, applying dynamic UI outlines based on structured assistant responses

## Testing
- npm run lint
- pytest # fails: ModuleNotFoundError: No module named 'app'

------
https://chatgpt.com/codex/tasks/task_e_68d8c42dba488327aed522cc28f1051e