### PR TITLE
Fix landing page scroll lock when loading with hash anchors

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -158,7 +158,7 @@ const heroStats = [
 
 export default function LandingPage(): JSX.Element {
   return (
-    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
+    <div className="relative min-h-screen overflow-x-hidden bg-slate-950 text-slate-100">
       <div
         className="absolute inset-0 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950"
         aria-hidden


### PR DESCRIPTION
## Summary
- allow the landing page container to scroll vertically even when loaded at an anchored section
- keep horizontal overflow clipped to preserve the background glow treatment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d944b4c1708327a8c7cf9da93faf88