### PR TITLE
Add shared banner navigation for UI routes

### DIFF
--- a/frontend/app/emotion-console/page.tsx
+++ b/frontend/app/emotion-console/page.tsx
@@ -6,6 +6,7 @@ import { Theme, Heading, Text } from "@radix-ui/themes";
 import "@radix-ui/themes/styles.css";
 
 import { Button } from "@/components/ui/button";
+import { PageBanner } from "@/components/page-banner";
 
 type EmotionProbabilities = Record<string, number>;
 
@@ -647,10 +648,17 @@ export default function EmotionConsole(): JSX.Element {
 
   return (
     <Theme appearance="inherit">
-      <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-10 px-6 py-12">
-        <section className="space-y-4">
-          <Heading as="h1" size="8" className="font-heading text-balance text-3xl md:text-4xl">
-            Multi-modal emotion console
+      <div className="min-h-screen bg-slate-100 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
+        <PageBanner
+          title="Multi-modal emotion console"
+          currentPage="Emotion Console"
+          containerClassName="max-w-6xl"
+          variant="light"
+        />
+        <main className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-6 py-12">
+          <section className="space-y-4">
+            <Heading as="h1" size="8" className="font-heading text-balance text-3xl md:text-4xl">
+              Multi-modal emotion console
           </Heading>
           <Text as="p" size="4" className="max-w-3xl text-slate-600 dark:text-slate-300">
             Capture voice, text, and facial movement in real time to infer emotions using a Plutchik-based taxonomy.
@@ -787,7 +795,8 @@ export default function EmotionConsole(): JSX.Element {
 
         {analysis ? <section className="grid gap-4 md:grid-cols-3">{breakdownCards}</section> : null}
       </main>
-    </Theme>
+    </div>
+  </Theme>
   );
 }
 

--- a/frontend/app/generative-ui/page.tsx
+++ b/frontend/app/generative-ui/page.tsx
@@ -6,6 +6,7 @@ import { Loader2, Palette, Sparkles } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { PageBanner } from "@/components/page-banner";
 
 const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
@@ -146,6 +147,11 @@ export default function GenerativeUIPage(): JSX.Element {
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
+      <PageBanner
+        title="Generative UI Studio"
+        currentPage="Generative UI"
+        containerClassName="max-w-7xl"
+      />
       <div className="mx-auto grid min-h-screen w-full max-w-7xl grid-cols-1 gap-6 px-6 py-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] lg:px-12">
         <section className="flex flex-col rounded-2xl border border-white/10 bg-slate-900/40 p-6 shadow-2xl shadow-cyan-900/20">
           <header className="flex items-start justify-between gap-3">

--- a/frontend/app/journal/page.tsx
+++ b/frontend/app/journal/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { PageBanner } from "@/components/page-banner";
 import {
   CalendarHeart,
   HeartHandshake,
@@ -178,6 +178,12 @@ export default function JournalStudioPage(): JSX.Element {
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#070b1a] text-slate-100">
+      <PageBanner
+        title="Evening Journal Studio"
+        currentPage="Journal"
+        containerClassName="max-w-6xl"
+        className="relative z-20 border-slate-800/60 bg-[#050814]/80"
+      />
       <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-emerald-500/10 via-transparent to-indigo-600/10" />
       <div className="pointer-events-none absolute -top-40 right-10 h-80 w-80 rounded-full bg-rose-500/20 blur-3xl" />
       <div className="pointer-events-none absolute -bottom-48 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-sky-500/20 blur-3xl" />
@@ -195,13 +201,6 @@ export default function JournalStudioPage(): JSX.Element {
               Settle into a guided reflection that mirrors the softness of twilight. Craft your entry, choose a mood, and receive gentle prompts, breathwork, and an affirmation curated just for tonight.
             </p>
           </div>
-          <nav className="flex items-center gap-3 text-sm text-slate-400">
-            <Link className="hover:text-slate-100" href="/">
-              Home
-            </Link>
-            <span className="text-slate-600">/</span>
-            <span className="text-slate-200">Journal</span>
-          </nav>
         </header>
 
         <section className="grid gap-10 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,0.85fr)]">

--- a/frontend/app/notes/page.tsx
+++ b/frontend/app/notes/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useCallback, useMemo, useRef, useState } from "react";
-import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
+import { PageBanner } from "@/components/page-banner";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
 
@@ -146,18 +146,7 @@ export default function NotesPage(): JSX.Element {
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
-      <header className="border-b border-slate-800 bg-slate-900/60 backdrop-blur">
-        <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-4">
-          <h1 className="text-xl font-semibold">AI Notes Workspace</h1>
-          <nav className="space-x-4 text-sm text-slate-400">
-            <Link href="/" className="hover:text-slate-100">
-              Home
-            </Link>
-            <span className="text-slate-700">/</span>
-            <span className="text-slate-100">Notes</span>
-          </nav>
-        </div>
-      </header>
+      <PageBanner title="AI Notes Workspace" currentPage="Notes" />
 
       <main className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-10">
         <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-6 shadow-lg">

--- a/frontend/app/realtime-assistant/page.tsx
+++ b/frontend/app/realtime-assistant/page.tsx
@@ -8,6 +8,7 @@ import "@radix-ui/themes/styles.css";
 
 import RealtimeConversationPanel from "@/components/realtime-conversation";
 import { Button } from "@/components/ui/button";
+import { PageBanner } from "@/components/page-banner";
 
 const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
@@ -366,40 +367,36 @@ export default function RealtimeAssistantPage(): JSX.Element {
 
   return (
     <Theme appearance="dark">
-      <main className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
+      <div className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
         <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.12),transparent_60%)]" />
         <div className="pointer-events-none absolute inset-0 -z-20 bg-[radial-gradient(circle_at_bottom_right,_rgba(16,185,129,0.12),transparent_55%)]" />
+        <PageBanner
+          title="Realtime assistant workspace"
+          currentPage="Realtime Assistant"
+          containerClassName="max-w-6xl"
+          className="relative z-20 border-slate-800/60 bg-slate-900/70"
+          actions={
+            <Button
+              asChild
+              className="bg-emerald-400 text-slate-950 shadow-[0_12px_30px_-18px_rgba(16,185,129,0.9)] transition-transform hover:-translate-y-0.5 hover:bg-emerald-300"
+            >
+              <Link href="/emotion-console">Open emotion console</Link>
+            </Button>
+          }
+        />
         <div
-          className="relative mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 pb-20 pt-10 sm:px-10"
+          className="relative mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 pb-20 pt-8 sm:px-10"
           ref={surfaceRef}
         >
           <div className="pointer-events-none absolute inset-x-0 top-16 mx-auto h-72 max-w-3xl rounded-full bg-emerald-500/10 blur-3xl" />
-          <header className="relative z-10 flex flex-wrap items-center justify-between gap-4 rounded-2xl border border-slate-800/60 bg-slate-900/70 px-6 py-5 shadow-[0_12px_40px_-24px_rgba(15,118,110,0.8)] backdrop-blur">
-            <div>
-              <Heading as="h1" size="5" className="font-heading text-slate-50">
-                Realtime assistant workspace
-              </Heading>
-              <Text className="mt-1 text-sm text-slate-300">
-                Speak with GPT-5 while sharing a live snapshot of the UI you are
-                viewing.
-              </Text>
-            </div>
-            <div className="flex items-center gap-3">
-              <Button
-                variant="ghost"
-                asChild
-                className="text-slate-200 hover:text-slate-50 hover:bg-slate-800/60"
-              >
-                <Link href="/">Back to studio</Link>
-              </Button>
-              <Button
-                asChild
-                className="bg-emerald-400 text-slate-950 shadow-[0_12px_30px_-18px_rgba(16,185,129,0.9)] transition-transform hover:-translate-y-0.5 hover:bg-emerald-300"
-              >
-                <Link href="/emotion-console">Open emotion console</Link>
-              </Button>
-            </div>
-          </header>
+          <section className="relative z-10 mt-6 rounded-2xl border border-slate-800/60 bg-slate-900/70 px-6 py-5 shadow-[0_12px_40px_-24px_rgba(15,118,110,0.8)] backdrop-blur">
+            <Heading as="h1" size="5" className="font-heading text-slate-50">
+              Realtime assistant workspace
+            </Heading>
+            <Text className="mt-1 text-sm text-slate-300">
+              Speak with GPT-5 while sharing a live snapshot of the UI you are viewing.
+            </Text>
+          </section>
 
           <section className="relative z-10 mt-10 grid gap-6 lg:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)]">
             <RealtimeConversationPanel
@@ -498,7 +495,7 @@ export default function RealtimeAssistantPage(): JSX.Element {
             </div>
           </section>
         </div>
-      </main>
+      </div>
     </Theme>
   );
 }

--- a/frontend/app/research-explorer/page.tsx
+++ b/frontend/app/research-explorer/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { type FormEvent, useCallback, useMemo, useState } from "react";
-import Link from "next/link";
 import {
   AlertTriangle,
   BookOpen,
@@ -17,6 +16,7 @@ import {
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { PageBanner } from "@/components/page-banner";
 
 const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
@@ -378,6 +378,12 @@ export default function ResearchExplorerPage(): JSX.Element {
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
+      <PageBanner
+        title="Research Explorer"
+        currentPage="Research Explorer"
+        containerClassName="max-w-6xl"
+        className="relative z-20 border-slate-800/70 bg-slate-950/80"
+      />
       <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950" />
       <div className="pointer-events-none absolute -left-24 top-10 h-72 w-72 rounded-full bg-emerald-500/20 blur-3xl" />
       <div className="pointer-events-none absolute -right-24 bottom-0 h-80 w-80 rounded-full bg-cyan-500/20 blur-3xl" />
@@ -395,13 +401,6 @@ export default function ResearchExplorerPage(): JSX.Element {
               Describe the research you need and watch GPT-5 expand your request, search arXiv, rerank with Cohere, and narrate why each paper matters—all in an OpenAI-style live trace.
             </p>
           </div>
-          <Button
-            asChild
-            variant="ghost"
-            className="self-start text-slate-300 hover:text-slate-50"
-          >
-            <Link href="/">Back to studio</Link>
-          </Button>
         </header>
 
         <section className="rounded-3xl border border-slate-800/70 bg-slate-950/60 p-8 shadow-2xl backdrop-blur">

--- a/frontend/app/tutor-mode/page.tsx
+++ b/frontend/app/tutor-mode/page.tsx
@@ -10,7 +10,6 @@ import {
   type KeyboardEvent,
   type SVGProps,
 } from "react";
-import Link from "next/link";
 import {
   BookOpen,
   CheckCircle2,
@@ -22,6 +21,7 @@ import {
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { PageBanner } from "@/components/page-banner";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
 
@@ -446,6 +446,12 @@ export default function TutorModePage(): JSX.Element {
 
   return (
     <div className="min-h-screen bg-slate-950 pb-16 text-slate-100">
+      <PageBanner
+        title="GPT-5 Tutor Collective"
+        currentPage="Tutor Mode"
+        containerClassName="max-w-6xl"
+        className="border-slate-900/70 bg-slate-950/80"
+      />
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 pb-12 pt-10 lg:px-6">
         <div className="flex items-center justify-between gap-4">
           <div>
@@ -458,13 +464,6 @@ export default function TutorModePage(): JSX.Element {
             <p className="mt-3 max-w-2xl text-sm text-slate-300">
               Describe what you want to learn and watch the manager agent rally a crew of specialists to design a personalised path.
             </p>
-          </div>
-          <div className="hidden shrink-0 md:block">
-            <Link href="/">
-              <Button variant="ghost" className="border border-slate-800 bg-slate-900/60 text-slate-200">
-                Back home
-              </Button>
-            </Link>
           </div>
         </div>
 

--- a/frontend/components/page-banner.tsx
+++ b/frontend/components/page-banner.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import Link from "next/link";
+import { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type PageBannerVariant = "dark" | "light";
+
+type VariantStyles = {
+  header: string;
+  title: string;
+  nav: string;
+  link: string;
+  divider: string;
+  current: string;
+};
+
+const VARIANT_STYLES: Record<PageBannerVariant, VariantStyles> = {
+  dark: {
+    header: "border-b border-slate-800 bg-slate-900/60 text-slate-100",
+    title: "text-slate-100",
+    nav: "text-slate-400",
+    link: "text-slate-400 transition-colors hover:text-slate-100",
+    divider: "text-slate-700",
+    current: "text-slate-100",
+  },
+  light: {
+    header: "border-b border-slate-200 bg-white/80 text-slate-900",
+    title: "text-slate-900",
+    nav: "text-slate-500",
+    link: "text-slate-600 transition-colors hover:text-slate-900",
+    divider: "text-slate-300",
+    current: "text-slate-900",
+  },
+};
+
+type PageBannerProps = {
+  title: string;
+  currentPage: string;
+  homeHref?: string;
+  homeLabel?: string;
+  variant?: PageBannerVariant;
+  className?: string;
+  containerClassName?: string;
+  actions?: ReactNode;
+};
+
+export function PageBanner({
+  title,
+  currentPage,
+  homeHref = "/",
+  homeLabel = "Home",
+  variant = "dark",
+  className,
+  containerClassName,
+  actions,
+}: PageBannerProps): JSX.Element {
+  const styles = VARIANT_STYLES[variant];
+
+  return (
+    <header className={cn("w-full backdrop-blur", styles.header, className)}>
+      <div
+        className={cn(
+          "mx-auto flex w-full items-center justify-between px-6 py-4",
+          containerClassName ?? "max-w-4xl"
+        )}
+      >
+        <h1 className={cn("text-xl font-semibold", styles.title)}>{title}</h1>
+        <div className="flex items-center gap-4">
+          <nav className={cn("flex items-center gap-3 text-sm", styles.nav)}>
+            <Link href={homeHref} className={styles.link}>
+              {homeLabel}
+            </Link>
+            <span className={styles.divider}>/</span>
+            <span className={styles.current}>{currentPage}</span>
+          </nav>
+          {actions ? <div className="flex items-center gap-2">{actions}</div> : null}
+        </div>
+      </div>
+    </header>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a reusable PageBanner component that supports dark and light themes plus optional action content
- integrate the banner across the notes, generative UI, emotion console, journal, realtime assistant, tutor mode, and research explorer pages for consistent home navigation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9437a4eac8327941ba60dbbc109b3