### PR TITLE
Add reusable page header banner across UI routes

### DIFF
--- a/frontend/app/emotion-console/page.tsx
+++ b/frontend/app/emotion-console/page.tsx
@@ -6,6 +6,7 @@ import { Theme, Heading, Text } from "@radix-ui/themes";
 import "@radix-ui/themes/styles.css";
 
 import { Button } from "@/components/ui/button";
+import { AppPageHeader } from "@/components/app-page-header";
 
 type EmotionProbabilities = Record<string, number>;
 
@@ -646,8 +647,14 @@ export default function EmotionConsole(): JSX.Element {
   }, [analysis]);
 
   return (
-    <Theme appearance="inherit">
-      <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-10 px-6 py-12">
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <AppPageHeader
+        title="Multi-modal emotion console"
+        breadcrumbLabel="Emotion Console"
+        description="Capture voice, text, and facial movement in real time to infer emotions."
+      />
+      <Theme appearance="inherit">
+        <main className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-6 py-12">
         <section className="space-y-4">
           <Heading as="h1" size="8" className="font-heading text-balance text-3xl md:text-4xl">
             Multi-modal emotion console
@@ -786,8 +793,9 @@ export default function EmotionConsole(): JSX.Element {
         </section>
 
         {analysis ? <section className="grid gap-4 md:grid-cols-3">{breakdownCards}</section> : null}
-      </main>
-    </Theme>
+        </main>
+      </Theme>
+    </div>
   );
 }
 

--- a/frontend/app/generative-ui/page.tsx
+++ b/frontend/app/generative-ui/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { CSSProperties, FormEvent, useMemo, useState } from "react";
 import Link from "next/link";
+import { CSSProperties, FormEvent, useMemo, useState } from "react";
 import { Loader2, Palette, Sparkles } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { AppPageHeader } from "@/components/app-page-header";
 
 const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
@@ -146,7 +147,8 @@ export default function GenerativeUIPage(): JSX.Element {
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
-      <div className="mx-auto grid min-h-screen w-full max-w-7xl grid-cols-1 gap-6 px-6 py-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] lg:px-12">
+      <AppPageHeader title="Generative UI Studio" breadcrumbLabel="Generative UI" />
+      <div className="mx-auto grid w-full max-w-7xl grid-cols-1 gap-6 px-6 py-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] lg:px-12">
         <section className="flex flex-col rounded-2xl border border-white/10 bg-slate-900/40 p-6 shadow-2xl shadow-cyan-900/20">
           <header className="flex items-start justify-between gap-3">
             <div>

--- a/frontend/app/journal/page.tsx
+++ b/frontend/app/journal/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -12,6 +11,7 @@ import {
   Sunrise,
   Waves,
 } from "lucide-react";
+import { AppPageHeader } from "@/components/app-page-header";
 
 const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
@@ -182,8 +182,16 @@ export default function JournalStudioPage(): JSX.Element {
       <div className="pointer-events-none absolute -top-40 right-10 h-80 w-80 rounded-full bg-rose-500/20 blur-3xl" />
       <div className="pointer-events-none absolute -bottom-48 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-sky-500/20 blur-3xl" />
 
+      <div className="relative z-10">
+        <AppPageHeader
+          title="Evening Journal Studio"
+          breadcrumbLabel="Journal"
+          description="Settle into a guided reflection crafted for twilight rituals."
+        />
+      </div>
+
       <main className="relative z-10 mx-auto flex w-full max-w-6xl flex-col gap-12 px-6 pb-20 pt-12 lg:px-12">
-        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <header className="flex flex-col gap-4">
           <div className="space-y-2">
             <span className="inline-flex items-center gap-2 rounded-full border border-rose-400/40 bg-rose-500/15 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-rose-100">
               <Sparkles className="h-3.5 w-3.5" /> Moonlight Rituals
@@ -195,13 +203,6 @@ export default function JournalStudioPage(): JSX.Element {
               Settle into a guided reflection that mirrors the softness of twilight. Craft your entry, choose a mood, and receive gentle prompts, breathwork, and an affirmation curated just for tonight.
             </p>
           </div>
-          <nav className="flex items-center gap-3 text-sm text-slate-400">
-            <Link className="hover:text-slate-100" href="/">
-              Home
-            </Link>
-            <span className="text-slate-600">/</span>
-            <span className="text-slate-200">Journal</span>
-          </nav>
         </header>
 
         <section className="grid gap-10 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,0.85fr)]">

--- a/frontend/app/notes/page.tsx
+++ b/frontend/app/notes/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useCallback, useMemo, useRef, useState } from "react";
-import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
+import { AppPageHeader } from "@/components/app-page-header";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
 
@@ -146,18 +146,7 @@ export default function NotesPage(): JSX.Element {
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
-      <header className="border-b border-slate-800 bg-slate-900/60 backdrop-blur">
-        <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-4">
-          <h1 className="text-xl font-semibold">AI Notes Workspace</h1>
-          <nav className="space-x-4 text-sm text-slate-400">
-            <Link href="/" className="hover:text-slate-100">
-              Home
-            </Link>
-            <span className="text-slate-700">/</span>
-            <span className="text-slate-100">Notes</span>
-          </nav>
-        </div>
-      </header>
+      <AppPageHeader title="AI Notes Workspace" breadcrumbLabel="Notes" />
 
       <main className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-10">
         <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-6 shadow-lg">

--- a/frontend/app/realtime-assistant/page.tsx
+++ b/frontend/app/realtime-assistant/page.tsx
@@ -8,6 +8,7 @@ import "@radix-ui/themes/styles.css";
 
 import RealtimeConversationPanel from "@/components/realtime-conversation";
 import { Button } from "@/components/ui/button";
+import { AppPageHeader } from "@/components/app-page-header";
 
 const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
@@ -365,8 +366,14 @@ export default function RealtimeAssistantPage(): JSX.Element {
   );
 
   return (
-    <Theme appearance="dark">
-      <main className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <AppPageHeader
+        title="Realtime assistant workspace"
+        breadcrumbLabel="Realtime Assistant"
+        description="Speak with GPT-5 while sharing a live snapshot of your UI."
+      />
+      <Theme appearance="dark">
+        <main className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
         <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.12),transparent_60%)]" />
         <div className="pointer-events-none absolute inset-0 -z-20 bg-[radial-gradient(circle_at_bottom_right,_rgba(16,185,129,0.12),transparent_55%)]" />
         <div
@@ -498,7 +505,8 @@ export default function RealtimeAssistantPage(): JSX.Element {
             </div>
           </section>
         </div>
-      </main>
-    </Theme>
+        </main>
+      </Theme>
+    </div>
   );
 }

--- a/frontend/app/research-explorer/page.tsx
+++ b/frontend/app/research-explorer/page.tsx
@@ -17,6 +17,7 @@ import {
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { AppPageHeader } from "@/components/app-page-header";
 
 const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
@@ -381,6 +382,14 @@ export default function ResearchExplorerPage(): JSX.Element {
       <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950" />
       <div className="pointer-events-none absolute -left-24 top-10 h-72 w-72 rounded-full bg-emerald-500/20 blur-3xl" />
       <div className="pointer-events-none absolute -right-24 bottom-0 h-80 w-80 rounded-full bg-cyan-500/20 blur-3xl" />
+
+      <div className="relative z-10">
+        <AppPageHeader
+          title="Research Explorer"
+          breadcrumbLabel="Research Explorer"
+          description="Streamed RAG that scouts papers and explains why they matter."
+        />
+      </div>
 
       <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 py-12 sm:px-10 lg:px-16">
         <header className="mb-10 flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">

--- a/frontend/app/tutor-mode/page.tsx
+++ b/frontend/app/tutor-mode/page.tsx
@@ -22,6 +22,7 @@ import {
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { AppPageHeader } from "@/components/app-page-header";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
 
@@ -446,6 +447,11 @@ export default function TutorModePage(): JSX.Element {
 
   return (
     <div className="min-h-screen bg-slate-950 pb-16 text-slate-100">
+      <AppPageHeader
+        title="Tutor mode"
+        breadcrumbLabel="Tutor Mode"
+        description="Ask the GPT-5 tutor collective anything."
+      />
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 pb-12 pt-10 lg:px-6">
         <div className="flex items-center justify-between gap-4">
           <div>

--- a/frontend/components/app-page-header.tsx
+++ b/frontend/components/app-page-header.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+
+export type AppPageHeaderProps = {
+  title: string;
+  description?: string;
+  breadcrumbLabel?: string;
+};
+
+export function AppPageHeader({
+  title,
+  description,
+  breadcrumbLabel,
+}: AppPageHeaderProps) {
+  const currentLabel = breadcrumbLabel ?? title;
+  return (
+    <header className="border-b border-slate-800 bg-slate-900/60 backdrop-blur">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-2 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-100">{title}</h1>
+          {description ? (
+            <p className="text-sm text-slate-400">{description}</p>
+          ) : null}
+        </div>
+        <nav className="flex items-center space-x-3 text-sm text-slate-400">
+          <Link href="/" className="hover:text-slate-100">
+            Home
+          </Link>
+          <span className="text-slate-700">/</span>
+          <span className="text-slate-100">{currentLabel}</span>
+        </nav>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add a shared `AppPageHeader` component that mirrors the Notes banner styling and breadcrumb
- integrate the header across emotion console, generative UI, journal, notes, realtime assistant, research explorer, and tutor mode pages with route-specific descriptions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9437a4eac8327941ba60dbbc109b3