### PR TITLE
feat: add shared workspace banner across UI pages

### DIFF
--- a/frontend/app/emotion-console/page.tsx
+++ b/frontend/app/emotion-console/page.tsx
@@ -6,6 +6,7 @@ import { Theme, Heading, Text } from "@radix-ui/themes";
 import "@radix-ui/themes/styles.css";
 
 import { Button } from "@/components/ui/button";
+import WorkspaceBanner from "@/components/workspace-banner";
 
 type EmotionProbabilities = Record<string, number>;
 
@@ -647,7 +648,19 @@ export default function EmotionConsole(): JSX.Element {
 
   return (
     <Theme appearance="inherit">
-      <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-10 px-6 py-12">
+      <div className="min-h-screen bg-slate-950 text-slate-100">
+        <WorkspaceBanner
+          title="Emotion Console"
+          current="Emotion Console"
+          subtitle="Monitor multi-modal sentiment across text, voice, and video"
+          maxWidthClassName="max-w-6xl"
+          rightSlot={
+            <Button asChild variant="outline" className="border-slate-700 bg-slate-900/60 text-slate-200">
+              <Link href="/realtime-assistant">Realtime assistant</Link>
+            </Button>
+          }
+        />
+        <main className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-6 py-12">
         <section className="space-y-4">
           <Heading as="h1" size="8" className="font-heading text-balance text-3xl md:text-4xl">
             Multi-modal emotion console
@@ -786,7 +799,8 @@ export default function EmotionConsole(): JSX.Element {
         </section>
 
         {analysis ? <section className="grid gap-4 md:grid-cols-3">{breakdownCards}</section> : null}
-      </main>
+        </main>
+      </div>
     </Theme>
   );
 }

--- a/frontend/app/generative-ui/page.tsx
+++ b/frontend/app/generative-ui/page.tsx
@@ -6,6 +6,7 @@ import { Loader2, Palette, Sparkles } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import WorkspaceBanner from "@/components/workspace-banner";
 
 const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
@@ -146,6 +147,12 @@ export default function GenerativeUIPage(): JSX.Element {
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
+      <WorkspaceBanner
+        title="Generative UI Studio"
+        current="Generative UI"
+        subtitle="Co-design live interfaces with GPT-5 as your palette partner"
+        maxWidthClassName="max-w-7xl"
+      />
       <div className="mx-auto grid min-h-screen w-full max-w-7xl grid-cols-1 gap-6 px-6 py-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] lg:px-12">
         <section className="flex flex-col rounded-2xl border border-white/10 bg-slate-900/40 p-6 shadow-2xl shadow-cyan-900/20">
           <header className="flex items-start justify-between gap-3">

--- a/frontend/app/journal/page.tsx
+++ b/frontend/app/journal/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import WorkspaceBanner from "@/components/workspace-banner";
 import {
   CalendarHeart,
   HeartHandshake,
@@ -182,6 +182,15 @@ export default function JournalStudioPage(): JSX.Element {
       <div className="pointer-events-none absolute -top-40 right-10 h-80 w-80 rounded-full bg-rose-500/20 blur-3xl" />
       <div className="pointer-events-none absolute -bottom-48 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-sky-500/20 blur-3xl" />
 
+      <div className="relative z-10">
+        <WorkspaceBanner
+          title="Evening Journal Studio"
+          current="Journal"
+          subtitle="Craft reflective rituals with mood-guided prompts"
+          maxWidthClassName="max-w-6xl"
+        />
+      </div>
+
       <main className="relative z-10 mx-auto flex w-full max-w-6xl flex-col gap-12 px-6 pb-20 pt-12 lg:px-12">
         <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="space-y-2">
@@ -195,13 +204,6 @@ export default function JournalStudioPage(): JSX.Element {
               Settle into a guided reflection that mirrors the softness of twilight. Craft your entry, choose a mood, and receive gentle prompts, breathwork, and an affirmation curated just for tonight.
             </p>
           </div>
-          <nav className="flex items-center gap-3 text-sm text-slate-400">
-            <Link className="hover:text-slate-100" href="/">
-              Home
-            </Link>
-            <span className="text-slate-600">/</span>
-            <span className="text-slate-200">Journal</span>
-          </nav>
         </header>
 
         <section className="grid gap-10 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,0.85fr)]">

--- a/frontend/app/notes/page.tsx
+++ b/frontend/app/notes/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useCallback, useMemo, useRef, useState } from "react";
-import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
+import WorkspaceBanner from "@/components/workspace-banner";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
 
@@ -146,18 +146,7 @@ export default function NotesPage(): JSX.Element {
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
-      <header className="border-b border-slate-800 bg-slate-900/60 backdrop-blur">
-        <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-4">
-          <h1 className="text-xl font-semibold">AI Notes Workspace</h1>
-          <nav className="space-x-4 text-sm text-slate-400">
-            <Link href="/" className="hover:text-slate-100">
-              Home
-            </Link>
-            <span className="text-slate-700">/</span>
-            <span className="text-slate-100">Notes</span>
-          </nav>
-        </div>
-      </header>
+      <WorkspaceBanner title="AI Notes Workspace" current="Notes" />
 
       <main className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-10">
         <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-6 shadow-lg">

--- a/frontend/app/realtime-assistant/page.tsx
+++ b/frontend/app/realtime-assistant/page.tsx
@@ -8,6 +8,7 @@ import "@radix-ui/themes/styles.css";
 
 import RealtimeConversationPanel from "@/components/realtime-conversation";
 import { Button } from "@/components/ui/button";
+import WorkspaceBanner from "@/components/workspace-banner";
 
 const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
@@ -366,40 +367,42 @@ export default function RealtimeAssistantPage(): JSX.Element {
 
   return (
     <Theme appearance="dark">
-      <main className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
-        <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.12),transparent_60%)]" />
-        <div className="pointer-events-none absolute inset-0 -z-20 bg-[radial-gradient(circle_at_bottom_right,_rgba(16,185,129,0.12),transparent_55%)]" />
-        <div
-          className="relative mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 pb-20 pt-10 sm:px-10"
-          ref={surfaceRef}
-        >
-          <div className="pointer-events-none absolute inset-x-0 top-16 mx-auto h-72 max-w-3xl rounded-full bg-emerald-500/10 blur-3xl" />
-          <header className="relative z-10 flex flex-wrap items-center justify-between gap-4 rounded-2xl border border-slate-800/60 bg-slate-900/70 px-6 py-5 shadow-[0_12px_40px_-24px_rgba(15,118,110,0.8)] backdrop-blur">
-            <div>
-              <Heading as="h1" size="5" className="font-heading text-slate-50">
-                Realtime assistant workspace
-              </Heading>
-              <Text className="mt-1 text-sm text-slate-300">
-                Speak with GPT-5 while sharing a live snapshot of the UI you are
-                viewing.
-              </Text>
-            </div>
-            <div className="flex items-center gap-3">
-              <Button
-                variant="ghost"
-                asChild
-                className="text-slate-200 hover:text-slate-50 hover:bg-slate-800/60"
-              >
-                <Link href="/">Back to studio</Link>
-              </Button>
+      <div className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
+        <div className="pointer-events-none absolute inset-0 -z-30 bg-[radial-gradient(circle_at_bottom_right,_rgba(16,185,129,0.12),transparent_55%)]" />
+        <div className="pointer-events-none absolute inset-0 -z-20 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.12),transparent_60%)]" />
+        <div className="relative z-20">
+          <WorkspaceBanner
+            title="Realtime Assistant"
+            current="Realtime Assistant"
+            subtitle="Speak with GPT-5 while it sees what you see"
+            maxWidthClassName="max-w-6xl"
+            rightSlot={
               <Button
                 asChild
                 className="bg-emerald-400 text-slate-950 shadow-[0_12px_30px_-18px_rgba(16,185,129,0.9)] transition-transform hover:-translate-y-0.5 hover:bg-emerald-300"
               >
-                <Link href="/emotion-console">Open emotion console</Link>
+                <Link href="/emotion-console">Emotion console</Link>
               </Button>
-            </div>
-          </header>
+            }
+          />
+        </div>
+        <main className="relative z-10">
+          <div
+            className="relative mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 pb-20 pt-10 sm:px-10"
+            ref={surfaceRef}
+          >
+            <div className="pointer-events-none absolute inset-x-0 top-16 mx-auto h-72 max-w-3xl rounded-full bg-emerald-500/10 blur-3xl" />
+            <header className="relative z-10 flex flex-wrap items-center justify-between gap-4 rounded-2xl border border-slate-800/60 bg-slate-900/70 px-6 py-5 shadow-[0_12px_40px_-24px_rgba(15,118,110,0.8)] backdrop-blur">
+              <div>
+                <Heading as="h1" size="5" className="font-heading text-slate-50">
+                  Realtime assistant workspace
+                </Heading>
+                <Text className="mt-1 text-sm text-slate-300">
+                  Speak with GPT-5 while sharing a live snapshot of the UI you are
+                  viewing.
+                </Text>
+              </div>
+            </header>
 
           <section className="relative z-10 mt-10 grid gap-6 lg:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)]">
             <RealtimeConversationPanel
@@ -499,6 +502,7 @@ export default function RealtimeAssistantPage(): JSX.Element {
           </section>
         </div>
       </main>
-    </Theme>
+    </div>
+  </Theme>
   );
 }

--- a/frontend/app/research-explorer/page.tsx
+++ b/frontend/app/research-explorer/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { type FormEvent, useCallback, useMemo, useState } from "react";
-import Link from "next/link";
 import {
   AlertTriangle,
   BookOpen,
@@ -17,6 +16,7 @@ import {
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import WorkspaceBanner from "@/components/workspace-banner";
 
 const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
@@ -382,6 +382,15 @@ export default function ResearchExplorerPage(): JSX.Element {
       <div className="pointer-events-none absolute -left-24 top-10 h-72 w-72 rounded-full bg-emerald-500/20 blur-3xl" />
       <div className="pointer-events-none absolute -right-24 bottom-0 h-80 w-80 rounded-full bg-cyan-500/20 blur-3xl" />
 
+      <div className="relative z-20">
+        <WorkspaceBanner
+          title="Research Explorer"
+          current="Research Explorer"
+          subtitle="Live-trace discovery for the papers you need"
+          maxWidthClassName="max-w-6xl"
+        />
+      </div>
+
       <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 py-12 sm:px-10 lg:px-16">
         <header className="mb-10 flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
           <div>
@@ -395,13 +404,6 @@ export default function ResearchExplorerPage(): JSX.Element {
               Describe the research you need and watch GPT-5 expand your request, search arXiv, rerank with Cohere, and narrate why each paper matters—all in an OpenAI-style live trace.
             </p>
           </div>
-          <Button
-            asChild
-            variant="ghost"
-            className="self-start text-slate-300 hover:text-slate-50"
-          >
-            <Link href="/">Back to studio</Link>
-          </Button>
         </header>
 
         <section className="rounded-3xl border border-slate-800/70 bg-slate-950/60 p-8 shadow-2xl backdrop-blur">

--- a/frontend/app/tutor-mode/page.tsx
+++ b/frontend/app/tutor-mode/page.tsx
@@ -10,7 +10,6 @@ import {
   type KeyboardEvent,
   type SVGProps,
 } from "react";
-import Link from "next/link";
 import {
   BookOpen,
   CheckCircle2,
@@ -22,6 +21,7 @@ import {
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import WorkspaceBanner from "@/components/workspace-banner";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
 
@@ -446,6 +446,12 @@ export default function TutorModePage(): JSX.Element {
 
   return (
     <div className="min-h-screen bg-slate-950 pb-16 text-slate-100">
+      <WorkspaceBanner
+        title="Tutor Mode Studio"
+        current="Tutor Mode"
+        subtitle="Assemble a collective of GPT-5 teaching agents"
+        maxWidthClassName="max-w-6xl"
+      />
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 pb-12 pt-10 lg:px-6">
         <div className="flex items-center justify-between gap-4">
           <div>
@@ -458,13 +464,6 @@ export default function TutorModePage(): JSX.Element {
             <p className="mt-3 max-w-2xl text-sm text-slate-300">
               Describe what you want to learn and watch the manager agent rally a crew of specialists to design a personalised path.
             </p>
-          </div>
-          <div className="hidden shrink-0 md:block">
-            <Link href="/">
-              <Button variant="ghost" className="border border-slate-800 bg-slate-900/60 text-slate-200">
-                Back home
-              </Button>
-            </Link>
           </div>
         </div>
 

--- a/frontend/components/workspace-banner.tsx
+++ b/frontend/components/workspace-banner.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type WorkspaceBannerProps = {
+  title: string;
+  current: string;
+  subtitle?: string;
+  maxWidthClassName?: string;
+  rightSlot?: ReactNode;
+};
+
+export default function WorkspaceBanner({
+  title,
+  current,
+  subtitle,
+  maxWidthClassName,
+  rightSlot,
+}: WorkspaceBannerProps): JSX.Element {
+  return (
+    <header className="border-b border-slate-800 bg-slate-900/60 backdrop-blur">
+      <div
+        className={cn(
+          "mx-auto flex w-full flex-col gap-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between",
+          maxWidthClassName ?? "max-w-4xl"
+        )}
+      >
+        <div className="space-y-1">
+          <h1 className="text-xl font-semibold text-slate-100">{title}</h1>
+          {subtitle ? <p className="text-sm text-slate-400">{subtitle}</p> : null}
+        </div>
+        <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:gap-4">
+          <nav className="flex items-center gap-2 text-sm text-slate-400">
+            <Link href="/" className="hover:text-slate-100">
+              Home
+            </Link>
+            <span className="text-slate-700">/</span>
+            <span className="text-slate-100">{current}</span>
+          </nav>
+          {rightSlot ? <div className="flex items-center gap-2">{rightSlot}</div> : null}
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable `WorkspaceBanner` component that renders the shared breadcrumb header with optional actions
- apply the banner across the notes, journal, generative UI, emotion console, realtime assistant, research explorer, and tutor mode pages for consistent navigation

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d9437a4eac8327941ba60dbbc109b3