### PR TITLE
Enable executable highlight instructions in realtime assistant

### DIFF
--- a/backend/app/schemas/realtime.py
+++ b/backend/app/schemas/realtime.py
@@ -12,11 +12,15 @@ class HighlightInstruction(BaseModel):
     """Instruction for the client to highlight a DOM element."""
 
     selector: str = Field(description="CSS selector targeting the DOM node")
-    action: Literal["highlight"] = Field(
+    action: Literal["highlight", "execute"] = Field(
         default="highlight", description="Type of UI affordance to perform"
     )
     reason: str | None = Field(
         default=None, description="Why the element should be highlighted"
+    )
+    script: str | None = Field(
+        default=None,
+        description="Optional JavaScript snippet to execute when action is 'execute'",
     )
 
 


### PR DESCRIPTION
## Summary
- allow realtime highlight instructions to carry optional scripts and execute them safely on the frontend
- extend backend realtime and vision payloads to propagate script-capable highlight instructions and update prompting
- add a graceful fallback vision analyzer so highlight execution works even when OpenAI credentials are absent

## Testing
- PYTHONPATH=backend pytest backend/tests/test_realtime.py

------
https://chatgpt.com/codex/tasks/task_e_68d94553e8e48327b5d5ed0303245c2c