### PR TITLE
Enable realtime assistant highlight script execution

### DIFF
--- a/backend/app/schemas/realtime.py
+++ b/backend/app/schemas/realtime.py
@@ -9,14 +9,22 @@ from pydantic import BaseModel, Field
 
 
 class HighlightInstruction(BaseModel):
-    """Instruction for the client to highlight a DOM element."""
+    """Instruction for the client to highlight or manipulate a DOM element."""
 
-    selector: str = Field(description="CSS selector targeting the DOM node")
-    action: Literal["highlight"] = Field(
+    selector: str | None = Field(
+        default=None, description="CSS selector targeting the DOM node"
+    )
+    action: Literal["highlight", "execute"] = Field(
         default="highlight", description="Type of UI affordance to perform"
     )
     reason: str | None = Field(
         default=None, description="Why the element should be highlighted"
+    )
+    script: str | None = Field(
+        default=None,
+        description=(
+            "Optional JavaScript snippet for the client to execute. Should return an optional cleanup function."
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- extend highlight instruction models to support optional DOM manipulation scripts alongside highlight actions
- propagate script-capable instructions through realtime session and vision responses
- run assistant-provided highlight scripts on the frontend with cleanup handling while preserving existing outline styling

## Testing
- pytest backend/tests/test_realtime.py *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68d94553e8e48327b5d5ed0303245c2c