### PR TITLE
Improve microphone permission flow

### DIFF
--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -39,6 +39,9 @@
       "tabs",
       "microphone"
     ],
+    "optional_permissions": [
+      "audioCapture"
+    ],
     "host_permissions": [
       "<all_urls>"
     ]


### PR DESCRIPTION
## Summary
- request optional audio capture permission before starting a realtime session
- surface clearer messaging and a quick link to Chrome microphone settings when access is denied
- keep side panel UI state consistent while handling microphone permission failures

## Testing
- npm run build *(fails: plasmo build cannot download package metadata without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68d94cdb4f2c8327be2929cb7a7822a3