### PR TITLE
Handle microphone permissions in side panel

### DIFF
--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -36,8 +36,11 @@
     "permissions": [
       "storage",
       "sidePanel",
-      "tabs",
-      "microphone"
+      "tabs"
+    ],
+    "optional_permissions": [
+      "microphone",
+      "audioCapture"
     ],
     "host_permissions": [
       "<all_urls>"


### PR DESCRIPTION
## Summary
- add an explicit microphone permission check in the side panel before starting a realtime session
- improve the error message when microphone access is blocked and request optional microphone permissions
- move microphone capture permissions to optional permissions in the manifest so they can be granted at runtime

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d94cdb4f2c8327be2929cb7a7822a3