### PR TITLE
Add streaming GPT-5 transcription and annotation for notes

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -11,6 +11,7 @@ from pydantic import HttpUrl
 
 from app.api.dependencies import (
     get_auth_client,
+    get_audio_transcriber,
     get_audio_storage,
     get_context_storage,
     get_emotion_analyzer,
@@ -55,6 +56,7 @@ from app.services.generative_ui import (
 )
 from app.services.journal import JournalCoach, JournalCoachError
 from app.services.note import NoteAnnotator, NoteAnnotationError
+from app.services.transcription import AudioTranscriber, AudioTranscriptionError
 from app.services.payment import StripePaymentError, StripePaymentService
 from app.services.realtime import RealtimeSessionClient, RealtimeSessionError
 from app.services.research import ResearchDiscoveryService
@@ -416,6 +418,164 @@ async def create_note(
         annotation=annotation.content,
         created_at=created_at,
     )
+
+
+@router.post("/notes/annotate", response_model=None, tags=["notes"])
+async def stream_note_annotation(
+    payload: NoteCreateRequest,
+    storage: S3AudioStorage = Depends(get_audio_storage),
+    annotator: NoteAnnotator = Depends(get_note_annotator),
+    transcriber: AudioTranscriber = Depends(get_audio_transcriber),
+) -> StreamingResponse:
+    """Stream the full note annotation workflow."""
+
+    async def event_stream():
+        annotation_chunks: list[str] = []
+        audio_bytes: bytes | None = None
+        audio_url: str | None = None
+        transcript_text: str | None = None
+
+        try:
+            yield _encode_event(
+                {
+                    "type": "status",
+                    "stage": "initializing",
+                    "message": "Preparing your note for GPT-5",
+                }
+            )
+
+            if payload.audio_base64:
+                try:
+                    audio_bytes = base64.b64decode(payload.audio_base64, validate=True)
+                except (binascii.Error, ValueError) as exc:
+                    raise ValueError("Invalid base64-encoded audio clip") from exc
+
+            if audio_bytes:
+                yield _encode_event(
+                    {
+                        "type": "status",
+                        "stage": "transcribing",
+                        "message": "Converting your voice memo to text",
+                    }
+                )
+
+                try:
+                    transcription = await transcriber.transcribe(audio_bytes, payload.audio_mime_type)
+                except AudioTranscriptionError as exc:
+                    raise RuntimeError(str(exc)) from exc
+
+                transcript_text = transcription.text
+                yield _encode_event(
+                    {
+                        "type": "transcript",
+                        "stage": "transcribing",
+                        "text": transcript_text,
+                    }
+                )
+
+                try:
+                    upload = storage.upload_audio(audio_bytes, payload.audio_mime_type)
+                    audio_url = upload.url
+                    yield _encode_event(
+                        {
+                            "type": "status",
+                            "stage": "uploading",
+                            "message": "Stored your voice memo securely",
+                        }
+                    )
+                except StorageServiceError as exc:
+                    raise RuntimeError(str(exc)) from exc
+
+            yield _encode_event(
+                {
+                    "type": "status",
+                    "stage": "annotating",
+                    "message": "Asking GPT-5 to polish your notes",
+                }
+            )
+
+            try:
+                async for delta in annotator.stream_annotation(
+                    title=payload.title,
+                    content=payload.content,
+                    audio_url=audio_url,
+                    transcript=transcript_text,
+                ):
+                    if delta:
+                        annotation_chunks.append(delta)
+                        yield _encode_event(
+                            {
+                                "type": "annotation_delta",
+                                "stage": "annotating",
+                                "delta": delta,
+                            }
+                        )
+            except NoteAnnotationError as exc:
+                raise RuntimeError(str(exc)) from exc
+
+            annotation_text = "".join(annotation_chunks).strip()
+            if not annotation_text:
+                try:
+                    fallback = await annotator.annotate(
+                        title=payload.title,
+                        content=payload.content,
+                        audio_url=audio_url,
+                        transcript=transcript_text,
+                    )
+                except NoteAnnotationError as exc:
+                    raise RuntimeError(str(exc)) from exc
+                annotation_text = fallback.content
+            created_at = datetime.now(timezone.utc)
+            note = NoteCreateResponse(
+                note_id=str(uuid4()),
+                title=payload.title,
+                content=payload.content,
+                audio_url=audio_url,
+                annotation=annotation_text,
+                created_at=created_at,
+            )
+
+            yield _encode_event(
+                {
+                    "type": "note_saved",
+                    "stage": "complete",
+                    "note": note.model_dump(mode="json"),
+                    "transcript": transcript_text,
+                }
+            )
+            yield _encode_event(
+                {
+                    "type": "complete",
+                    "stage": "complete",
+                    "message": "Annotation finished",
+                }
+            )
+        except ValueError as exc:
+            yield _encode_event(
+                {
+                    "type": "error",
+                    "stage": "error",
+                    "message": str(exc),
+                }
+            )
+        except RuntimeError as exc:
+            yield _encode_event(
+                {
+                    "type": "error",
+                    "stage": "error",
+                    "message": str(exc),
+                }
+            )
+        except Exception:  # pragma: no cover - defensive guard
+            yield _encode_event(
+                {
+                    "type": "error",
+                    "stage": "error",
+                    "message": "An unexpected error occurred while annotating the note.",
+                }
+            )
+
+    return StreamingResponse(event_stream(), media_type="application/jsonl")
 
 
 @router.post("/journals", response_model=JournalEntryResponse, tags=["journals"])

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -23,6 +23,9 @@ class Settings(BaseSettings):
     openai_vision_model: str = Field(
         default="gpt-5", alias="OPENAI_VISION_MODEL"
     )
+    openai_transcription_model: str = Field(
+        default="gpt-4o-transcribe", alias="OPENAI_TRANSCRIPTION_MODEL"
+    )
     openai_annotation_model: str = Field(
         default="gpt-5", alias="OPENAI_ANNOTATION_MODEL"
     )

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -13,6 +13,7 @@ from .note import AnnotationResult, NoteAnnotator, NoteAnnotationError
 from .payment import CheckoutSession, StripePaymentError, StripePaymentService
 from .research import ResearchDiscoveryService
 from .storage import AudioUploadResult, S3AudioStorage, StorageServiceError
+from .transcription import AudioTranscriber, AudioTranscriptionError, TranscriptionResult
 from .tutor import TutorModeService
 
 __all__ = [
@@ -38,6 +39,9 @@ __all__ = [
     "AudioUploadResult",
     "S3AudioStorage",
     "StorageServiceError",
+    "AudioTranscriber",
+    "AudioTranscriptionError",
+    "TranscriptionResult",
     "TutorModeService",
     "ResearchDiscoveryService",
 ]

--- a/backend/app/services/note.py
+++ b/backend/app/services/note.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from typing import AsyncGenerator
 
 import httpx
 
@@ -26,12 +28,52 @@ class NoteAnnotator:
         self._base_url = base_url.rstrip("/")
         self._model = model
 
+    def _build_payload(
+        self,
+        *,
+        title: str,
+        content: str,
+        audio_url: str | None,
+        transcript: str | None,
+    ) -> dict[str, object]:
+        """Create the payload used for both standard and streamed requests."""
+
+        system_lines = [
+            "You are an expert research assistant that organizes meeting notes.",
+            "Provide a concise annotated summary, key action items, and follow-up questions.",
+        ]
+        if transcript:
+            system_lines.append("Use the provided voice memo transcript to enrich the summary.")
+        elif audio_url:
+            system_lines.append(
+                "An audio recording of the conversation is available at the following URL for additional context:"
+            )
+            system_lines.append(audio_url)
+
+        user_sections = [f"Title: {title}", "", content]
+        if transcript:
+            user_sections.extend(
+                ["", "Voice memo transcript:", transcript]
+            )
+
+        return {
+            "model": self._model,
+            "messages": [
+                {"role": "system", "content": "\n".join(system_lines)},
+                {
+                    "role": "user",
+                    "content": "\n".join(user_sections),
+                },
+            ],
+        }
+
     async def annotate(
         self,
         *,
         title: str,
         content: str,
         audio_url: str | None,
+        transcript: str | None = None,
     ) -> AnnotationResult:
         """Request an annotation summary for the provided note."""
 
@@ -39,26 +81,12 @@ class NoteAnnotator:
             "Authorization": f"Bearer {self._api_key}",
             "Content-Type": "application/json",
         }
-        system_lines = [
-            "You are an expert research assistant that organizes meeting notes.",
-            "Provide a concise annotated summary, key action items, and follow-up questions.",
-        ]
-        if audio_url:
-            system_lines.append(
-                "An audio recording of the conversation is available at the following URL for additional context:"
-            )
-            system_lines.append(audio_url)
-
-        payload = {
-            "model": self._model,
-            "messages": [
-                {"role": "system", "content": "\n".join(system_lines)},
-                {
-                    "role": "user",
-                    "content": f"Title: {title}\n\n{content}",
-                },
-            ],
-        }
+        payload = self._build_payload(
+            title=title,
+            content=content,
+            audio_url=audio_url,
+            transcript=transcript,
+        )
 
         async with httpx.AsyncClient(timeout=30.0) as client:
             try:
@@ -76,6 +104,64 @@ class NoteAnnotator:
             raise NoteAnnotationError("Unexpected response from annotation service") from exc
 
         return AnnotationResult(content=message)
+
+    async def stream_annotation(
+        self,
+        *,
+        title: str,
+        content: str,
+        audio_url: str | None,
+        transcript: str | None,
+    ) -> AsyncGenerator[str, None]:
+        """Yield annotation deltas as the model streams them back."""
+
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = self._build_payload(
+            title=title,
+            content=content,
+            audio_url=audio_url,
+            transcript=transcript,
+        )
+        payload["stream"] = True
+
+        async with httpx.AsyncClient(timeout=None) as client:
+            try:
+                async with client.stream(
+                    "POST",
+                    f"{self._base_url}/chat/completions",
+                    headers=headers,
+                    json=payload,
+                ) as response:
+                    response.raise_for_status()
+
+                    async for line in response.aiter_lines():
+                        if not line:
+                            continue
+                        chunk = line
+                        if chunk.startswith("data:"):
+                            chunk = chunk[5:].strip()
+                        else:
+                            chunk = chunk.strip()
+                        if not chunk:
+                            continue
+                        if chunk == "[DONE]":
+                            break
+
+                        try:
+                            data = json.loads(chunk)
+                            delta = data["choices"][0]["delta"].get("content")
+                        except (json.JSONDecodeError, KeyError, IndexError, TypeError) as exc:
+                            raise NoteAnnotationError(
+                                "Unexpected response from annotation service"
+                            ) from exc
+
+                        if delta:
+                            yield delta
+            except httpx.HTTPError as exc:  # pragma: no cover - network errors not deterministic
+                raise NoteAnnotationError("Failed to contact the annotation service") from exc
 
 
 __all__ = ["AnnotationResult", "NoteAnnotator", "NoteAnnotationError"]

--- a/backend/app/services/transcription.py
+++ b/backend/app/services/transcription.py
@@ -1,0 +1,64 @@
+"""Audio transcription helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import httpx
+
+
+class AudioTranscriptionError(RuntimeError):
+    """Raised when the transcription service fails."""
+
+
+@dataclass
+class TranscriptionResult:
+    """Return payload for an audio transcription request."""
+
+    text: str
+
+
+class AudioTranscriber:
+    """Thin wrapper around the OpenAI transcription endpoint."""
+
+    def __init__(self, api_key: str, base_url: str, model: str) -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._model = model
+
+    async def transcribe(
+        self,
+        payload: bytes,
+        content_type: str | None,
+    ) -> TranscriptionResult:
+        """Transcribe the provided audio bytes into text."""
+
+        headers = {"Authorization": f"Bearer {self._api_key}"}
+        form = {"model": (None, self._model)}
+
+        mime = content_type or "audio/webm"
+        files = {"file": ("recording.webm", payload, mime)}
+
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            try:
+                response = await client.post(
+                    f"{self._base_url}/audio/transcriptions",
+                    headers=headers,
+                    data=form,
+                    files=files,
+                )
+                response.raise_for_status()
+            except httpx.HTTPError as exc:  # pragma: no cover - network errors not deterministic
+                raise AudioTranscriptionError("Failed to contact the transcription service") from exc
+
+        data = response.json()
+        try:
+            text = data["text"].strip()
+        except (KeyError, TypeError) as exc:
+            raise AudioTranscriptionError("Unexpected response from transcription service") from exc
+
+        return TranscriptionResult(text=text)
+
+
+__all__ = ["AudioTranscriber", "AudioTranscriptionError", "TranscriptionResult"]
+


### PR DESCRIPTION
## Summary
- add a /notes/annotate streaming endpoint that transcribes audio, stores recordings, and streams annotation deltas
- introduce an OpenAI audio transcription service and wire it through configuration and dependencies
- update the notes workspace UI to consume the streamed transcript/annotation and show live status updates

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'app' during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68d94f9f4fa88327a0b5805e08c1126b