### PR TITLE
Add interactive animation to landing page star icon

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -269,7 +269,20 @@ export default function LandingPage(): JSX.Element {
                 <div className="relative flex flex-col gap-6">
                   <div className="flex items-center justify-between text-sm text-slate-300">
                     <span className="inline-flex items-center gap-2">
-                      <Star className="h-4 w-4 text-amber-200" />
+                      <span className="group/star relative inline-flex h-7 w-7 items-center justify-center">
+                        <span
+                          className="absolute inset-0 -z-10 rounded-full bg-amber-200/20 opacity-70 blur-md transition duration-500 group-hover/star:scale-125 group-hover/star:opacity-100 motion-safe:animate-starHalo motion-reduce:animate-none"
+                          aria-hidden
+                        />
+                        <span
+                          className="absolute inset-0 -z-20 rounded-full border border-amber-200/60 opacity-0 group-hover/star:animate-starBurst motion-reduce:group-hover/star:animate-none"
+                          aria-hidden
+                        />
+                        <Star
+                          className="h-4 w-4 text-amber-200 drop-shadow-[0_0_8px_rgba(253,224,71,0.65)] transition-transform duration-500 group-hover/star:rotate-12 group-hover/star:scale-110 motion-safe:animate-starTwinkle motion-reduce:animate-none motion-reduce:transition-none"
+                          aria-hidden
+                        />
+                      </span>
                       Glow dashboard
                     </span>
                     <span className="inline-flex items-center gap-2 text-amber-100">

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -20,6 +20,27 @@ const config: Config = {
           DEFAULT: "#0F172A",
           foreground: "#F8FAFC"
         }
+      },
+      keyframes: {
+        starTwinkle: {
+          "0%, 100%": { transform: "scale(1) rotate(0deg)" },
+          "35%": { transform: "scale(1.08) rotate(-4deg)" },
+          "65%": { transform: "scale(1.08) rotate(3deg)" }
+        },
+        starHalo: {
+          "0%, 100%": { transform: "scale(0.9)", opacity: "0.3" },
+          "50%": { transform: "scale(1.08)", opacity: "0.6" }
+        },
+        starBurst: {
+          "0%": { transform: "scale(0.6)", opacity: "0" },
+          "60%": { transform: "scale(1.15)", opacity: "0.35" },
+          "100%": { transform: "scale(1.4)", opacity: "0" }
+        }
+      },
+      animation: {
+        starTwinkle: "starTwinkle 2.8s ease-in-out infinite",
+        starHalo: "starHalo 3.6s ease-in-out infinite",
+        starBurst: "starBurst 0.9s ease-out forwards"
       }
     }
   },


### PR DESCRIPTION
## Summary
- add layered halo and burst effects around the Glow dashboard star icon for hover interaction
- introduce reusable Tailwind keyframes for star twinkle, halo pulse, and burst animations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d966e38e9483278a32ed321e129ebc