### PR TITLE
Add interactive animation to landing page star badge

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -268,8 +268,24 @@ export default function LandingPage(): JSX.Element {
                 <div className="absolute left-10 top-10 h-48 w-48 rounded-full bg-[radial-gradient(circle,_rgba(253,224,71,0.4),_rgba(2,6,23,0))] blur-xl" />
                 <div className="relative flex flex-col gap-6">
                   <div className="flex items-center justify-between text-sm text-slate-300">
-                    <span className="inline-flex items-center gap-2">
-                      <Star className="h-4 w-4 text-amber-200" />
+                    <span className="group relative inline-flex items-center gap-2">
+                      <span className="relative flex h-7 w-7 items-center justify-center">
+                        <span
+                          aria-hidden
+                          className="absolute inset-0 rounded-full bg-amber-200/20 blur-lg opacity-0 transition-opacity duration-500 group-hover:opacity-80"
+                        />
+                        <Star
+                          className="relative h-5 w-5 text-amber-200 transition-transform duration-500 group-hover:rotate-6 group-hover:scale-110 animate-starPulse"
+                        />
+                        <span
+                          aria-hidden
+                          className="absolute -top-1.5 -right-1 h-2 w-2 rounded-full bg-amber-100/90 opacity-0 group-hover:opacity-100 group-hover:animate-sparkle"
+                        />
+                        <span
+                          aria-hidden
+                          className="absolute -bottom-1 left-0 h-1.5 w-1.5 rounded-full bg-white/80 opacity-0 group-hover:opacity-100 group-hover:animate-sparkle [animation-delay:300ms]"
+                        />
+                      </span>
                       Glow dashboard
                     </span>
                     <span className="inline-flex items-center gap-2 text-amber-100">

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -20,6 +20,36 @@ const config: Config = {
           DEFAULT: "#0F172A",
           foreground: "#F8FAFC"
         }
+      },
+      keyframes: {
+        starPulse: {
+          "0%, 100%": {
+            transform: "scale(1) rotate(0deg)",
+            filter: "drop-shadow(0 0 0 rgba(253, 224, 71, 0.35))"
+          },
+          "50%": {
+            transform: "scale(1.08) rotate(3deg)",
+            filter: "drop-shadow(0 0 18px rgba(253, 224, 71, 0.55))"
+          }
+        },
+        sparkle: {
+          "0%": {
+            transform: "translate3d(0, 0, 0) scale(0.4)",
+            opacity: "0"
+          },
+          "45%": {
+            transform: "translate3d(12%, -45%, 0) scale(1)",
+            opacity: "1"
+          },
+          "100%": {
+            transform: "translate3d(28%, -80%, 0) scale(0.2)",
+            opacity: "0"
+          }
+        }
+      },
+      animation: {
+        starPulse: "starPulse 3.6s ease-in-out infinite",
+        sparkle: "sparkle 2s ease-in-out infinite"
       }
     }
   },


### PR DESCRIPTION
## Summary
- add an animated, interactive treatment to the Glow dashboard star icon on the landing page
- define reusable Tailwind keyframes and animation utilities for the pulsing star and sparkle accents

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d966e38e9483278a32ed321e129ebc