### PR TITLE
Refactor tutor mode into manager and specialist agents

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -13,7 +13,7 @@ from app.services.payment import StripePaymentService
 from app.services.realtime import RealtimeSessionClient
 from app.services.research import ResearchDiscoveryService
 from app.services.storage import S3AudioStorage, StorageServiceError
-from app.services.tutor import TutorModeService
+from app.services.tutor import TutorAgentService
 from app.services.context_storage import get_context_storage
 from app.services.vision import VisionAnalyzer
 
@@ -186,18 +186,14 @@ def get_research_service() -> ResearchDiscoveryService:
 
 
 @lru_cache
-def _get_tutor_service() -> TutorModeService:
+def _get_tutor_service() -> TutorAgentService:
     """Return a singleton tutor mode service configured from settings."""
 
-    settings = _get_settings()
-    return TutorModeService(
-        api_key=settings.openai_api_key,
-        base_url=settings.openai_api_base_url,
-        model="gpt-5",
-    )
+    _get_settings()  # Ensure configuration is loaded before instantiating the service.
+    return TutorAgentService(model="gpt-5")
 
 
-def get_tutor_service() -> TutorModeService:
+def get_tutor_service() -> TutorAgentService:
     """FastAPI dependency wrapper around the tutor service singleton."""
 
     return _get_tutor_service()

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -46,7 +46,13 @@ from app.schemas.realtime import (
 from app.schemas.journal import JournalEntryRequest, JournalEntryResponse
 from app.schemas.research import ResearchPaperSummary, ResearchSearchRequest
 from app.schemas.note import NoteCreateRequest, NoteCreateResponse
-from app.schemas.tutor import TutorModeRequest, TutorModeResponse
+from app.schemas.tutor import (
+    TutorAssessmentResponse,
+    TutorCurriculumResponse,
+    TutorManagerResponse,
+    TutorModeRequest,
+    TutorWorkshopResponse,
+)
 from app.services.auth import Auth0Client, Auth0ClientError
 from app.services.emotion import EmotionAnalyzer
 from app.services.generative_ui import (
@@ -61,7 +67,7 @@ from app.services.payment import StripePaymentError, StripePaymentService
 from app.services.realtime import RealtimeSessionClient, RealtimeSessionError
 from app.services.research import ResearchDiscoveryService
 # from app.services.storage import S3AudioStorage, StorageServiceError  # Commented out AWS S3 for now
-from app.services.tutor import TutorModeService
+from app.services.tutor import TutorAgentService
 from app.services.vision import (
     VisionAnalysisError,
     VisionAnalyzer,
@@ -659,14 +665,54 @@ async def create_checkout_session(
     return PaymentCheckoutResponse(session_id=session.session_id, checkout_url=session.url)
 
 
-@router.post("/tutor/mode", response_model=TutorModeResponse, tags=["tutor"])
-async def create_tutor_mode_plan(
+@router.post("/tutor/mode", response_model=TutorManagerResponse, tags=["tutor"])
+async def create_tutor_manager_plan(
     payload: TutorModeRequest,
-    tutor_service: TutorModeService = Depends(get_tutor_service),
-) -> TutorModeResponse:
-    """Create a BabyAGI-inspired tutoring plan powered by GPT-5."""
+    tutor_service: TutorAgentService = Depends(get_tutor_service),
+) -> TutorManagerResponse:
+    """Coordinate the tutor collective and return the manager's delegation plan."""
 
-    return await tutor_service.generate_plan(payload)
+    return tutor_service.manager_plan(payload)
+
+
+@router.post("/tutor/manager", response_model=TutorManagerResponse, tags=["tutor"])
+async def create_tutor_manager_alias(
+    payload: TutorModeRequest,
+    tutor_service: TutorAgentService = Depends(get_tutor_service),
+) -> TutorManagerResponse:
+    """Alias for /tutor/mode providing the same manager output."""
+
+    return tutor_service.manager_plan(payload)
+
+
+@router.post("/tutor/curriculum", response_model=TutorCurriculumResponse, tags=["tutor"])
+async def create_tutor_curriculum_plan(
+    payload: TutorModeRequest,
+    tutor_service: TutorAgentService = Depends(get_tutor_service),
+) -> TutorCurriculumResponse:
+    """Generate the curriculum strategist's blueprint."""
+
+    return tutor_service.curriculum_plan(payload)
+
+
+@router.post("/tutor/workshop", response_model=TutorWorkshopResponse, tags=["tutor"])
+async def create_tutor_workshop_plan(
+    payload: TutorModeRequest,
+    tutor_service: TutorAgentService = Depends(get_tutor_service),
+) -> TutorWorkshopResponse:
+    """Return a hands-on workshop design for immediate practice."""
+
+    return tutor_service.workshop_plan(payload)
+
+
+@router.post("/tutor/assessment", response_model=TutorAssessmentResponse, tags=["tutor"])
+async def create_tutor_assessment_plan(
+    payload: TutorModeRequest,
+    tutor_service: TutorAgentService = Depends(get_tutor_service),
+) -> TutorAssessmentResponse:
+    """Deliver a mastery check crafted by the assessment architect."""
+
+    return tutor_service.assessment_plan(payload)
 
 
 def _encode_event(payload: dict[str, object]) -> str:

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -14,7 +14,7 @@ from .payment import CheckoutSession, StripePaymentError, StripePaymentService
 from .research import ResearchDiscoveryService
 from .storage import AudioUploadResult, S3AudioStorage, StorageServiceError
 from .transcription import AudioTranscriber, AudioTranscriptionError, TranscriptionResult
-from .tutor import TutorModeService
+from .tutor import TutorAgentService
 
 __all__ = [
     "Auth0Client",
@@ -42,6 +42,6 @@ __all__ = [
     "AudioTranscriber",
     "AudioTranscriptionError",
     "TranscriptionResult",
-    "TutorModeService",
+    "TutorAgentService",
     "ResearchDiscoveryService",
 ]

--- a/backend/tests/test_tutor.py
+++ b/backend/tests/test_tutor.py
@@ -3,41 +3,78 @@ from fastapi.testclient import TestClient
 from app.main import app
 
 
-def test_tutor_mode_offline_plan_structure() -> None:
-    """Tutor mode returns a rich plan even without an OpenAI API key."""
-
-    payload = {
+def _payload() -> dict[str, object]:
+    return {
         "topic": "Neural Networks",
         "student_level": "Beginner programmer transitioning into ML",
         "goals": ["Understand core building blocks", "Implement a simple network"],
         "preferred_modalities": ["visual", "interactive"],
+        "additional_context": "Wants to build a side project in 4 weeks",
     }
 
+
+def test_tutor_manager_routes_agents() -> None:
+    """The manager route should describe every specialist agent."""
+
     with TestClient(app) as client:
-        response = client.post("/api/v1/tutor/mode", json=payload)
+        response = client.post("/api/v1/tutor/mode", json=_payload())
 
     assert response.status_code == 200
     data = response.json()
 
-    assert data["model"] == "gpt-5"
-    assert data["topic"] == payload["topic"]
-    assert data["learner_profile"]
-    assert data["objectives"]
+    assert data["topic"] == "Neural Networks"
+    assert data["summary"]
+    assert data["agenda"], "Expected manager agenda to be populated"
 
-    understanding = data["understanding"]
-    assert understanding["diagnostic_questions"], "Expected diagnostic questions in plan"
+    agent_ids = {agent["id"] for agent in data["agents"]}
+    assert {"curriculum", "workshop", "assessment"}.issubset(agent_ids)
 
-    concepts = data["concept_breakdown"]
-    assert isinstance(concepts, list) and len(concepts) >= 1
-    assert concepts[0]["llm_reasoning"]
 
-    modalities = data["teaching_modalities"]
-    assert {modality["modality"] for modality in modalities} >= {"visual", "interactive", "verbal"}
+def test_curriculum_agent_returns_sections() -> None:
+    """Curriculum strategist should provide a multi-stage roadmap."""
 
-    assessment = data["assessment"]
-    assert assessment["human_in_the_loop_notes"]
-    assert any(item["kind"] == "practical" for item in assessment["items"])
+    with TestClient(app) as client:
+        response = client.post("/api/v1/tutor/curriculum", json=_payload())
 
-    completion = data["completion"]
-    assert completion["mastery_indicators"]
-    assert completion["follow_up_suggestions"]
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["overview"], "Overview should explain the roadmap"
+    sections = data["sections"]
+    assert isinstance(sections, list) and len(sections) >= 3
+    for section in sections:
+        assert section["learning_goals"], "Each section needs learning goals"
+        assert section["activities"], "Each section needs activities"
+        assert section["assessment"], "Each section needs a mastery check"
+
+
+def test_workshop_agent_outlines_segments() -> None:
+    """Workshop designer should structure a live session."""
+
+    with TestClient(app) as client:
+        response = client.post("/api/v1/tutor/workshop", json=_payload())
+
+    assert response.status_code == 200
+    data = response.json()
+
+    segments = data["segments"]
+    assert isinstance(segments, list) and len(segments) >= 3
+    for segment in segments:
+        assert segment["flow"], "Segments should describe the facilitation flow"
+        assert segment["reflection_prompts"], "Segments should include reflection prompts"
+
+
+def test_assessment_agent_provides_answer_keys() -> None:
+    """Assessment architect should return answer keys for every question."""
+
+    with TestClient(app) as client:
+        response = client.post("/api/v1/tutor/assessment", json=_payload())
+
+    assert response.status_code == 200
+    data = response.json()
+
+    questions = data["questions"]
+    assert isinstance(questions, list) and questions
+    for question in questions:
+        assert question["answer"], "Every question needs an answer or rubric"
+        assert question["rationale"], "Each answer should explain the reasoning"


### PR DESCRIPTION
## Summary
- replace the legacy tutor plan schema with manager, curriculum, workshop, and assessment agent payloads and add a deterministic TutorAgentService for each
- expose new /tutor/mode, /tutor/curriculum, /tutor/workshop, and /tutor/assessment endpoints and update automated coverage for the refreshed contracts
- rebuild the tutor mode front-end to orchestrate the agents, display their outputs, and deliver an interactive quiz experience

## Testing
- PYTHONPATH=backend pytest backend/tests/test_tutor.py

------
https://chatgpt.com/codex/tasks/task_e_68dae0a43f2c8327b86a61d557b16ee4